### PR TITLE
bugfix: save node id in sequence when dag walking and node executed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,6 @@ replace (
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.21.2
 	k8s.io/apimachinery => k8s.io/apimachinery v0.21.2
 	k8s.io/apiserver => k8s.io/apiserver v0.21.2
-	k8s.io/cli-runtime => k8s.io/cli-runtime v0.21.2
 	k8s.io/client-go => k8s.io/client-go v0.21.2
 	k8s.io/cloud-provider => k8s.io/cloud-provider v0.21.2
 	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.21.2

--- a/pkg/engine/operation/apply.go
+++ b/pkg/engine/operation/apply.go
@@ -83,7 +83,6 @@ func (o *Operation) Apply(request *ApplyRequest) (rsp *ApplyResponse, st status.
 			CtxResourceIndex:        map[string]*states.ResourceState{},
 			PriorStateResourceIndex: priorStateResourceIndex,
 			StateResourceIndex:      priorStateResourceIndex,
-			ChangeStepMap:           o.ChangeStepMap,
 			Runtime:                 o.Runtime,
 			MsgCh:                   o.MsgCh,
 			resultState:             resultState,
@@ -127,14 +126,14 @@ func (o *Operation) applyWalkFun(v dag.Vertex) (diags tfdiags.Diagnostics) {
 		if rn, ok2 := v.(*ResourceNode); ok2 {
 			o.MsgCh <- Message{rn.Hashcode().(string), "", nil}
 
-			s = node.Execute(*o)
+			s = node.Execute(o)
 			if status.IsErr(s) {
 				o.MsgCh <- Message{rn.Hashcode().(string), Failed, fmt.Errorf("node execte failed, status: %v", s)}
 			} else {
 				o.MsgCh <- Message{rn.Hashcode().(string), Success, nil}
 			}
 		} else {
-			s = node.Execute(*o)
+			s = node.Execute(o)
 		}
 	}
 	if s != nil {

--- a/pkg/engine/operation/apply_test.go
+++ b/pkg/engine/operation/apply_test.go
@@ -59,7 +59,7 @@ func TestOperation_Apply(t *testing.T) {
 		CtxResourceIndex        map[string]*states.ResourceState
 		PriorStateInstanceIndex map[string]*states.ResourceState
 		StateResourceIndex      map[string]*states.ResourceState
-		ChangeStepMap           map[string]*ChangeStep
+		Order                   *ChangeOrder
 		Runtime                 runtime.Runtime
 		MsgCh                   chan Message
 		resultState             *states.State
@@ -137,14 +137,14 @@ func TestOperation_Apply(t *testing.T) {
 				CtxResourceIndex:        tt.fields.CtxResourceIndex,
 				PriorStateResourceIndex: tt.fields.PriorStateInstanceIndex,
 				StateResourceIndex:      tt.fields.StateResourceIndex,
-				ChangeStepMap:           tt.fields.ChangeStepMap,
+				Order:                   tt.fields.Order,
 				Runtime:                 tt.fields.Runtime,
 				MsgCh:                   tt.fields.MsgCh,
 				resultState:             tt.fields.resultState,
 				lock:                    tt.fields.lock,
 			}
 
-			monkey.Patch((*ResourceNode).Execute, func(rn *ResourceNode, operation Operation) status.Status {
+			monkey.Patch((*ResourceNode).Execute, func(rn *ResourceNode, operation *Operation) status.Status {
 				o.resultState = rs
 				return nil
 			})

--- a/pkg/engine/operation/destory.go
+++ b/pkg/engine/operation/destory.go
@@ -71,7 +71,6 @@ func (o *Operation) Destroy(request *DestroyRequest) (st status.Status) {
 			CtxResourceIndex:        map[string]*states.ResourceState{},
 			PriorStateResourceIndex: priorStateResourceIndex,
 			StateResourceIndex:      priorStateResourceIndex,
-			ChangeStepMap:           o.ChangeStepMap,
 			Runtime:                 o.Runtime,
 			MsgCh:                   o.MsgCh,
 			resultState:             resultState,
@@ -79,7 +78,7 @@ func (o *Operation) Destroy(request *DestroyRequest) (st status.Status) {
 		},
 	}
 
-	w := dag.Walker{Callback: do.applyWalkFun}
+	w := &dag.Walker{Callback: do.applyWalkFun}
 	w.Update(graph)
 	// Wait
 	if diags := w.Wait(); diags.HasErrors() {

--- a/pkg/engine/operation/destory_test.go
+++ b/pkg/engine/operation/destory_test.go
@@ -48,7 +48,7 @@ func TestOperation_Destroy(t *testing.T) {
 
 	t.Run("destroy success", func(t *testing.T) {
 		defer monkey.UnpatchAll()
-		monkey.Patch((*ResourceNode).Execute, func(rn *ResourceNode, operation Operation) status.Status {
+		monkey.Patch((*ResourceNode).Execute, func(rn *ResourceNode, operation *Operation) status.Status {
 			return nil
 		})
 		o.MsgCh = make(chan Message, 1)
@@ -59,7 +59,7 @@ func TestOperation_Destroy(t *testing.T) {
 
 	t.Run("destroy failed", func(t *testing.T) {
 		defer monkey.UnpatchAll()
-		monkey.Patch((*ResourceNode).Execute, func(rn *ResourceNode, operation Operation) status.Status {
+		monkey.Patch((*ResourceNode).Execute, func(rn *ResourceNode, operation *Operation) status.Status {
 			return status.NewErrorStatus(errors.New("mock error"))
 		})
 

--- a/pkg/engine/operation/executable_node.go
+++ b/pkg/engine/operation/executable_node.go
@@ -3,5 +3,5 @@ package operation
 import "kusionstack.io/kusion/pkg/status"
 
 type ExecutableNode interface {
-	Execute(operation Operation) status.Status
+	Execute(operation *Operation) status.Status
 }

--- a/pkg/engine/operation/operation.go
+++ b/pkg/engine/operation/operation.go
@@ -24,11 +24,12 @@ type Operation struct {
 	PriorStateResourceIndex map[string]*states.ResourceState
 	// StateResourceIndex represents resources that will be saved in states.StateStorage
 	StateResourceIndex map[string]*states.ResourceState
-	ChangeStepMap      map[string]*ChangeStep
-	Runtime            runtime.Runtime
-	MsgCh              chan Message
-	resultState        *states.State
-	lock               *sync.Mutex
+	// Order contains id to action of resource node in preview order
+	Order       *ChangeOrder
+	Runtime     runtime.Runtime
+	MsgCh       chan Message
+	resultState *states.State
+	lock        *sync.Mutex
 }
 
 type Message struct {

--- a/pkg/engine/operation/preview.go
+++ b/pkg/engine/operation/preview.go
@@ -22,7 +22,7 @@ type PreviewRequest struct {
 }
 
 type PreviewResponse struct {
-	ChangeSteps map[string]*ChangeStep
+	Order *ChangeOrder
 }
 
 func (o *Operation) Preview(request *PreviewRequest, operation Type) (rsp *PreviewResponse, s status.Status) {
@@ -76,20 +76,20 @@ func (o *Operation) Preview(request *PreviewRequest, operation Type) (rsp *Previ
 			CtxResourceIndex:        map[string]*states.ResourceState{},
 			PriorStateResourceIndex: priorStateResourceIndex,
 			StateResourceIndex:      priorStateResourceIndex,
-			ChangeStepMap:           o.ChangeStepMap,
+			Order:                   o.Order,
 			resultState:             resultState,
 			lock:                    &sync.Mutex{},
 		},
 	}
 
-	w := dag.Walker{Callback: previewOperation.previewWalkFun}
+	w := &dag.Walker{Callback: previewOperation.previewWalkFun}
 	w.Update(graph)
 	// Wait
 	if diags := w.Wait(); diags.HasErrors() {
 		return nil, status.NewErrorStatus(diags.Err())
 	}
 
-	return &PreviewResponse{ChangeSteps: previewOperation.ChangeStepMap}, nil
+	return &PreviewResponse{Order: previewOperation.Order}, nil
 }
 
 func (po *PreviewOperation) previewWalkFun(v dag.Vertex) (diags tfdiags.Diagnostics) {
@@ -114,7 +114,7 @@ func (po *PreviewOperation) previewWalkFun(v dag.Vertex) (diags tfdiags.Diagnost
 	}()
 
 	if node, ok := v.(ExecutableNode); ok {
-		s = node.Execute(po.Operation)
+		s = node.Execute(&po.Operation)
 		if status.IsErr(s) {
 			diags = diags.Append(fmt.Errorf("node execute failed, status: %v", s))
 			return diags

--- a/pkg/engine/operation/preview_test.go
+++ b/pkg/engine/operation/preview_test.go
@@ -38,7 +38,7 @@ func TestOperation_Preview(t *testing.T) {
 		CtxResourceIndex        map[string]*states.ResourceState
 		PriorStateResourceIndex map[string]*states.ResourceState
 		StateResourceIndex      map[string]*states.ResourceState
-		ChangeStepMap           map[string]*ChangeStep
+		Order                   *ChangeOrder
 		Runtime                 runtime.Runtime
 		MsgCh                   chan Message
 		resultState             *states.State
@@ -58,9 +58,9 @@ func TestOperation_Preview(t *testing.T) {
 		{
 			name: "success-when-apply",
 			fields: fields{
-				Runtime:       &runtime.KubernetesRuntime{},
-				StateStorage:  &states.FileSystemState{Path: states.KusionState},
-				ChangeStepMap: map[string]*ChangeStep{},
+				Runtime:      &runtime.KubernetesRuntime{},
+				StateStorage: &states.FileSystemState{Path: states.KusionState},
+				Order:        &ChangeOrder{StepKeys: []string{}, ChangeSteps: map[string]*ChangeStep{}},
 			},
 			args: args{
 				request: &PreviewRequest{
@@ -79,12 +79,15 @@ func TestOperation_Preview(t *testing.T) {
 				operation: Apply,
 			},
 			wantRsp: &PreviewResponse{
-				ChangeSteps: map[string]*ChangeStep{
-					"fake-id": {
-						ID:     "fake-id",
-						Action: Create,
-						Old:    (*states.ResourceState)(nil),
-						New:    &FakeResourceState,
+				Order: &ChangeOrder{
+					StepKeys: []string{"fake-id"},
+					ChangeSteps: map[string]*ChangeStep{
+						"fake-id": {
+							ID:     "fake-id",
+							Action: Create,
+							Old:    (*states.ResourceState)(nil),
+							New:    &FakeResourceState,
+						},
 					},
 				},
 			},
@@ -93,9 +96,9 @@ func TestOperation_Preview(t *testing.T) {
 		{
 			name: "success-when-destroy",
 			fields: fields{
-				Runtime:       &runtime.KubernetesRuntime{},
-				StateStorage:  &states.FileSystemState{Path: states.KusionState},
-				ChangeStepMap: map[string]*ChangeStep{},
+				Runtime:      &runtime.KubernetesRuntime{},
+				StateStorage: &states.FileSystemState{Path: states.KusionState},
+				Order:        &ChangeOrder{},
 			},
 			args: args{
 				request: &PreviewRequest{
@@ -114,12 +117,15 @@ func TestOperation_Preview(t *testing.T) {
 				operation: Destroy,
 			},
 			wantRsp: &PreviewResponse{
-				ChangeSteps: map[string]*ChangeStep{
-					"fake-id": {
-						ID:     "fake-id",
-						Action: Delete,
-						Old:    &FakeResourceState,
-						New:    (*states.ResourceState)(nil),
+				Order: &ChangeOrder{
+					StepKeys: []string{"fake-id"},
+					ChangeSteps: map[string]*ChangeStep{
+						"fake-id": {
+							ID:     "fake-id",
+							Action: Delete,
+							Old:    &FakeResourceState,
+							New:    (*states.ResourceState)(nil),
+						},
 					},
 				},
 			},
@@ -128,9 +134,9 @@ func TestOperation_Preview(t *testing.T) {
 		{
 			name: "fail-because-empty-manifest",
 			fields: fields{
-				Runtime:       &runtime.KubernetesRuntime{},
-				StateStorage:  &states.FileSystemState{Path: states.KusionState},
-				ChangeStepMap: map[string]*ChangeStep{},
+				Runtime:      &runtime.KubernetesRuntime{},
+				StateStorage: &states.FileSystemState{Path: states.KusionState},
+				Order:        &ChangeOrder{},
 			},
 			args: args{
 				request: &PreviewRequest{
@@ -146,9 +152,9 @@ func TestOperation_Preview(t *testing.T) {
 		{
 			name: "fail-because-nonexistent-id",
 			fields: fields{
-				Runtime:       &runtime.KubernetesRuntime{},
-				StateStorage:  &states.FileSystemState{Path: states.KusionState},
-				ChangeStepMap: map[string]*ChangeStep{},
+				Runtime:      &runtime.KubernetesRuntime{},
+				StateStorage: &states.FileSystemState{Path: states.KusionState},
+				Order:        &ChangeOrder{},
 			},
 			args: args{
 				request: &PreviewRequest{
@@ -183,7 +189,7 @@ func TestOperation_Preview(t *testing.T) {
 				CtxResourceIndex:        tt.fields.CtxResourceIndex,
 				PriorStateResourceIndex: tt.fields.PriorStateResourceIndex,
 				StateResourceIndex:      tt.fields.StateResourceIndex,
-				ChangeStepMap:           tt.fields.ChangeStepMap,
+				Order:                   tt.fields.Order,
 				Runtime:                 tt.fields.Runtime,
 				MsgCh:                   tt.fields.MsgCh,
 				resultState:             tt.fields.resultState,

--- a/pkg/engine/operation/resource_node.go
+++ b/pkg/engine/operation/resource_node.go
@@ -20,7 +20,7 @@ type ResourceNode struct {
 
 var _ ExecutableNode = (*ResourceNode)(nil)
 
-func (rn *ResourceNode) Execute(operation Operation) status.Status {
+func (rn *ResourceNode) Execute(operation *Operation) status.Status {
 	log.Debugf("execute node:%s", rn.ID)
 	// 1. prepare planedState
 	planedState := rn.state
@@ -52,12 +52,12 @@ func (rn *ResourceNode) Execute(operation Operation) status.Status {
 	} else {
 		rn.Action = Update
 	}
-	fillResponseChangeSteps(operation, rn, priorState, planedState)
 
-	// 4. apply
 	if operation.OperationType == Preview {
+		fillResponseChangeSteps(operation, rn, priorState, planedState)
 		return nil
 	}
+	// 4. apply
 	switch rn.Action {
 	case Create, Delete, Update:
 		s := rn.applyResource(operation, priorState, planedState)
@@ -72,7 +72,7 @@ func (rn *ResourceNode) Execute(operation Operation) status.Status {
 	return nil
 }
 
-func (rn *ResourceNode) applyResource(operation Operation, priorState *states.ResourceState, planedState *states.ResourceState) status.Status {
+func (rn *ResourceNode) applyResource(operation *Operation, priorState *states.ResourceState, planedState *states.ResourceState) status.Status {
 	log.Infof("PriorAttributes and PlanAttributes are not equal. operation:%v, prior:%v, plan:%v", rn.Action,
 		jsonUtil.Marshal2String(priorState), jsonUtil.Marshal2String(planedState))
 	var res *states.ResourceState
@@ -119,14 +119,22 @@ func NewResourceNode(key string, state *states.ResourceState, action ActionType)
 	return &ResourceNode{BaseNode: BaseNode{ID: key}, Action: action, state: state}
 }
 
-func fillResponseChangeSteps(operation Operation, rn *ResourceNode, prior, plan interface{}) {
+func fillResponseChangeSteps(operation *Operation, rn *ResourceNode, prior, plan interface{}) {
 	defer operation.lock.Unlock()
 	operation.lock.Lock()
 
-	if operation.ChangeStepMap == nil {
-		operation.ChangeStepMap = make(map[string]*ChangeStep)
+	order := operation.Order
+	if order == nil {
+		order = &ChangeOrder{
+			StepKeys:    []string{},
+			ChangeSteps: make(map[string]*ChangeStep),
+		}
 	}
-	operation.ChangeStepMap[rn.ID] = NewChangeStep(rn.ID, rn.Action, prior, plan)
+	if order.ChangeSteps == nil {
+		order.ChangeSteps = make(map[string]*ChangeStep)
+	}
+	order.StepKeys = append(order.StepKeys, rn.ID)
+	order.ChangeSteps[rn.ID] = NewChangeStep(rn.ID, rn.Action, prior, plan)
 }
 
 var ImplicitReplaceFun = func(resourceIndex map[string]*states.ResourceState, refPath string) (reflect.Value, status.Status) {

--- a/pkg/engine/operation/resource_node_test.go
+++ b/pkg/engine/operation/resource_node_test.go
@@ -174,7 +174,7 @@ func TestResourceNode_Execute(t *testing.T) {
 				})
 			defer monkey.UnpatchAll()
 
-			assert.Equalf(t, tt.want, rn.Execute(tt.args.operation), "Execute(%v)", tt.args.operation)
+			assert.Equalf(t, tt.want, rn.Execute(&tt.args.operation), "Execute(%v)", tt.args.operation)
 		})
 	}
 }

--- a/pkg/kusionctl/cmd/apply/options.go
+++ b/pkg/kusionctl/cmd/apply/options.go
@@ -141,9 +141,9 @@ func preview(o *ApplyOptions, planResources *manifest.Manifest,
 
 	pc := &operation.PreviewOperation{
 		Operation: operation.Operation{
-			Runtime:       kubernetesRuntime,
-			StateStorage:  &states.FileSystemState{Path: filepath.Join(o.WorkDir, states.KusionState)},
-			ChangeStepMap: map[string]*operation.ChangeStep{},
+			Runtime:      kubernetesRuntime,
+			StateStorage: &states.FileSystemState{Path: filepath.Join(o.WorkDir, states.KusionState)},
+			Order:        &operation.ChangeOrder{StepKeys: []string{}, ChangeSteps: map[string]*operation.ChangeStep{}},
 		},
 	}
 
@@ -162,7 +162,7 @@ func preview(o *ApplyOptions, planResources *manifest.Manifest,
 		return nil, fmt.Errorf("preview failed.\n%s", s.String())
 	}
 
-	return operation.NewChanges(project, stack, rsp.ChangeSteps), nil
+	return operation.NewChanges(project, stack, rsp.Order), nil
 }
 
 func apply(o *ApplyOptions, planResources *manifest.Manifest, changes *operation.Changes) error {
@@ -174,10 +174,9 @@ func apply(o *ApplyOptions, planResources *manifest.Manifest, changes *operation
 
 	ac := &operation.ApplyOperation{
 		Operation: operation.Operation{
-			Runtime:       kubernetesRuntime,
-			StateStorage:  &states.FileSystemState{Path: filepath.Join(o.WorkDir, states.KusionState)},
-			MsgCh:         make(chan operation.Message),
-			ChangeStepMap: map[string]*operation.ChangeStep{},
+			Runtime:      kubernetesRuntime,
+			StateStorage: &states.FileSystemState{Path: filepath.Join(o.WorkDir, states.KusionState)},
+			MsgCh:        make(chan operation.Message),
 		},
 	}
 
@@ -185,7 +184,7 @@ func apply(o *ApplyOptions, planResources *manifest.Manifest, changes *operation
 	var ls lineSummary
 
 	// progress bar, print dag walk detail
-	progressbar, err := pterm.DefaultProgressbar.WithTotal(len(changes.ChangeSteps)).Start()
+	progressbar, err := pterm.DefaultProgressbar.WithTotal(len(changes.StepKeys)).Start()
 	if err != nil {
 		return err
 	}

--- a/pkg/kusionctl/cmd/apply/options_test.go
+++ b/pkg/kusionctl/cmd/apply/options_test.go
@@ -151,24 +151,27 @@ func mockOperationPreview() {
 	monkey.Patch((*operation.Operation).Preview,
 		func(*operation.Operation, *operation.PreviewRequest, operation.Type) (rsp *operation.PreviewResponse, s status.Status) {
 			return &operation.PreviewResponse{
-				ChangeSteps: map[string]*operation.ChangeStep{
-					sa1.ID: {
-						ID:     sa1.ID,
-						Action: operation.Create,
-						Old:    nil,
-						New:    &sa1,
-					},
-					sa2.ID: {
-						ID:     sa2.ID,
-						Action: operation.UnChange,
-						Old:    &sa2,
-						New:    &sa2,
-					},
-					sa3.ID: {
-						ID:     sa3.ID,
-						Action: operation.Undefined,
-						Old:    &sa3,
-						New:    &sa1,
+				Order: &operation.ChangeOrder{
+					StepKeys: []string{sa1.ID, sa2.ID, sa3.ID},
+					ChangeSteps: map[string]*operation.ChangeStep{
+						sa1.ID: {
+							ID:     sa1.ID,
+							Action: operation.Create,
+							Old:    nil,
+							New:    &sa1,
+						},
+						sa2.ID: {
+							ID:     sa2.ID,
+							Action: operation.UnChange,
+							Old:    &sa2,
+							New:    &sa2,
+						},
+						sa3.ID: {
+							ID:     sa3.ID,
+							Action: operation.Undefined,
+							Old:    &sa3,
+							New:    &sa1,
+						},
 					},
 				},
 			}, nil
@@ -209,15 +212,18 @@ func Test_apply(t *testing.T) {
 		mockNewKubernetesRuntime()
 
 		planResources := &manifest.Manifest{Resources: []states.ResourceState{sa1}}
-		changeSteps := map[string]*operation.ChangeStep{
-			sa1.ID: {
-				ID:     sa1.ID,
-				Action: operation.Create,
-				Old:    nil,
-				New:    sa1,
+		order := &operation.ChangeOrder{
+			StepKeys: []string{sa1.ID},
+			ChangeSteps: map[string]*operation.ChangeStep{
+				sa1.ID: {
+					ID:     sa1.ID,
+					Action: operation.Create,
+					Old:    nil,
+					New:    sa1,
+				},
 			},
 		}
-		changes := operation.NewChanges(project, stack, changeSteps)
+		changes := operation.NewChanges(project, stack, order)
 		o := NewApplyOptions()
 		o.DryRun = true
 		err := apply(o, planResources, changes)
@@ -230,21 +236,24 @@ func Test_apply(t *testing.T) {
 
 		o := NewApplyOptions()
 		planResources := &manifest.Manifest{Resources: []states.ResourceState{sa1, sa2}}
-		changeSteps := map[string]*operation.ChangeStep{
-			sa1.ID: {
-				ID:     sa1.ID,
-				Action: operation.Create,
-				Old:    nil,
-				New:    &sa1,
-			},
-			sa2.ID: {
-				ID:     sa2.ID,
-				Action: operation.UnChange,
-				Old:    &sa2,
-				New:    &sa2,
+		order := &operation.ChangeOrder{
+			StepKeys: []string{sa1.ID, sa2.ID},
+			ChangeSteps: map[string]*operation.ChangeStep{
+				sa1.ID: {
+					ID:     sa1.ID,
+					Action: operation.Create,
+					Old:    nil,
+					New:    &sa1,
+				},
+				sa2.ID: {
+					ID:     sa2.ID,
+					Action: operation.UnChange,
+					Old:    &sa2,
+					New:    &sa2,
+				},
 			},
 		}
-		changes := operation.NewChanges(project, stack, changeSteps)
+		changes := operation.NewChanges(project, stack, order)
 
 		err := apply(o, planResources, changes)
 		assert.Nil(t, err)
@@ -256,15 +265,18 @@ func Test_apply(t *testing.T) {
 
 		o := NewApplyOptions()
 		planResources := &manifest.Manifest{Resources: []states.ResourceState{sa1}}
-		changeSteps := map[string]*operation.ChangeStep{
-			sa1.ID: {
-				ID:     sa1.ID,
-				Action: operation.Create,
-				Old:    nil,
-				New:    &sa1,
+		order := &operation.ChangeOrder{
+			StepKeys: []string{sa1.ID},
+			ChangeSteps: map[string]*operation.ChangeStep{
+				sa1.ID: {
+					ID:     sa1.ID,
+					Action: operation.Create,
+					Old:    nil,
+					New:    &sa1,
+				},
 			},
 		}
-		changes := operation.NewChanges(project, stack, changeSteps)
+		changes := operation.NewChanges(project, stack, order)
 
 		err := apply(o, planResources, changes)
 		assert.NotNil(t, err)

--- a/pkg/kusionctl/cmd/destroy/options.go
+++ b/pkg/kusionctl/cmd/destroy/options.go
@@ -126,9 +126,9 @@ func (o *DestroyOptions) preview(planResources *manifest.Manifest,
 
 	pc := &operation.PreviewOperation{
 		Operation: operation.Operation{
-			Runtime:       kubernetesRuntime,
-			StateStorage:  &states.FileSystemState{Path: filepath.Join(o.WorkDir, states.KusionState)},
-			ChangeStepMap: map[string]*operation.ChangeStep{},
+			Runtime:      kubernetesRuntime,
+			StateStorage: &states.FileSystemState{Path: filepath.Join(o.WorkDir, states.KusionState)},
+			Order:        &operation.ChangeOrder{StepKeys: []string{}, ChangeSteps: map[string]*operation.ChangeStep{}},
 		},
 	}
 
@@ -147,7 +147,7 @@ func (o *DestroyOptions) preview(planResources *manifest.Manifest,
 		return nil, fmt.Errorf("preview failed, status: %v", s)
 	}
 
-	return operation.NewChanges(project, stack, rsp.ChangeSteps), nil
+	return operation.NewChanges(project, stack, rsp.Order), nil
 }
 
 func (o *DestroyOptions) destroy(planResources *manifest.Manifest, changes *operation.Changes) error {
@@ -159,10 +159,9 @@ func (o *DestroyOptions) destroy(planResources *manifest.Manifest, changes *oper
 
 	do := &operation.DestroyOperation{
 		Operation: operation.Operation{
-			Runtime:       kubernetesRuntime,
-			StateStorage:  &states.FileSystemState{Path: filepath.Join(o.WorkDir, states.KusionState)},
-			MsgCh:         make(chan operation.Message),
-			ChangeStepMap: map[string]*operation.ChangeStep{},
+			Runtime:      kubernetesRuntime,
+			StateStorage: &states.FileSystemState{Path: filepath.Join(o.WorkDir, states.KusionState)},
+			MsgCh:        make(chan operation.Message),
 		},
 	}
 
@@ -170,7 +169,7 @@ func (o *DestroyOptions) destroy(planResources *manifest.Manifest, changes *oper
 	var deleted int
 
 	// progress bar, print dag walk detail
-	progressbar, err := pterm.DefaultProgressbar.WithTotal(len(changes.ChangeSteps)).Start()
+	progressbar, err := pterm.DefaultProgressbar.WithTotal(len(changes.StepKeys)).Start()
 	if err != nil {
 		return err
 	}

--- a/pkg/kusionctl/cmd/destroy/options_test.go
+++ b/pkg/kusionctl/cmd/destroy/options_test.go
@@ -143,12 +143,15 @@ func mockOperationPreview() {
 	monkey.Patch((*operation.Operation).Preview,
 		func(*operation.Operation, *operation.PreviewRequest, operation.Type) (rsp *operation.PreviewResponse, s status.Status) {
 			return &operation.PreviewResponse{
-				ChangeSteps: map[string]*operation.ChangeStep{
-					sa1.ID: {
-						ID:     sa1.ID,
-						Action: operation.Delete,
-						Old:    &sa1,
-						New:    nil,
+				Order: &operation.ChangeOrder{
+					StepKeys: []string{sa1.ID},
+					ChangeSteps: map[string]*operation.ChangeStep{
+						sa1.ID: {
+							ID:     sa1.ID,
+							Action: operation.Delete,
+							Old:    &sa1,
+							New:    nil,
+						},
 					},
 				},
 			}, nil
@@ -190,21 +193,24 @@ func Test_destroy(t *testing.T) {
 
 		o := NewDestroyOptions()
 		planResources := &manifest.Manifest{Resources: []states.ResourceState{sa2}}
-		changeSteps := map[string]*operation.ChangeStep{
-			sa1.ID: {
-				ID:     sa1.ID,
-				Action: operation.Delete,
-				Old:    &sa1,
-				New:    nil,
-			},
-			sa2.ID: {
-				ID:     sa2.ID,
-				Action: operation.UnChange,
-				Old:    &sa2,
-				New:    &sa2,
+		order := &operation.ChangeOrder{
+			StepKeys: []string{sa1.ID, sa2.ID},
+			ChangeSteps: map[string]*operation.ChangeStep{
+				sa1.ID: {
+					ID:     sa1.ID,
+					Action: operation.Delete,
+					Old:    &sa1,
+					New:    nil,
+				},
+				sa2.ID: {
+					ID:     sa2.ID,
+					Action: operation.UnChange,
+					Old:    &sa2,
+					New:    &sa2,
+				},
 			},
 		}
-		changes := operation.NewChanges(project, stack, changeSteps)
+		changes := operation.NewChanges(project, stack, order)
 
 		err := o.destroy(planResources, changes)
 		assert.Nil(t, err)
@@ -216,15 +222,18 @@ func Test_destroy(t *testing.T) {
 
 		o := NewDestroyOptions()
 		planResources := &manifest.Manifest{Resources: []states.ResourceState{sa1}}
-		changeSteps := map[string]*operation.ChangeStep{
-			sa1.ID: {
-				ID:     sa1.ID,
-				Action: operation.Delete,
-				Old:    &sa1,
-				New:    nil,
+		order := &operation.ChangeOrder{
+			StepKeys: []string{sa1.ID},
+			ChangeSteps: map[string]*operation.ChangeStep{
+				sa1.ID: {
+					ID:     sa1.ID,
+					Action: operation.Delete,
+					Old:    &sa1,
+					New:    nil,
+				},
 			},
 		}
-		changes := operation.NewChanges(project, stack, changeSteps)
+		changes := operation.NewChanges(project, stack, order)
 
 		err := o.destroy(planResources, changes)
 		assert.NotNil(t, err)


### PR DESCRIPTION
When `kusion apply` in `preview` stage, the previewed table not always the same.

Cause
- after pre-dependent nodes finished, these downEdges are executing in paralyzing, so we cannot ensure the key returned from resource_node.execute() are alway the same.
- map traversing(node id -> action), it is originally disordered.

Fix
- ignore concurrent execution of peer nodes
- save node id in sequence, keep order by traversing slice instead of map
