### PR TITLE
bugfix: save node id in sequence when dag walking and node executed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,6 @@ replace (
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.21.2
 	k8s.io/apimachinery => k8s.io/apimachinery v0.21.2
 	k8s.io/apiserver => k8s.io/apiserver v0.21.2
-	k8s.io/cli-runtime => k8s.io/cli-runtime v0.21.2
 	k8s.io/client-go => k8s.io/client-go v0.21.2
 	k8s.io/cloud-provider => k8s.io/cloud-provider v0.21.2
 	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.21.2

--- a/pkg/engine/operation/apply.go
+++ b/pkg/engine/operation/apply.go
@@ -86,7 +86,6 @@ func (o *Operation) Apply(request *ApplyRequest) (rsp *ApplyResponse, st status.
 			CtxResourceIndex:        map[string]*states.ResourceState{},
 			PriorStateResourceIndex: priorStateResourceIndex,
 			StateResourceIndex:      priorStateResourceIndex,
-			ChangeStepMap:           o.ChangeStepMap,
 			Runtime:                 o.Runtime,
 			MsgCh:                   o.MsgCh,
 			resultState:             resultState,
@@ -132,14 +131,14 @@ func (o *Operation) applyWalkFun(v dag.Vertex) (diags tfdiags.Diagnostics) {
 		if rn, ok2 := v.(*ResourceNode); ok2 {
 			o.MsgCh <- Message{rn.Hashcode().(string), "", nil}
 
-			s = node.Execute(*o)
+			s = node.Execute(o)
 			if status.IsErr(s) {
 				o.MsgCh <- Message{rn.Hashcode().(string), Failed, fmt.Errorf("node execte failed, status: %v", s)}
 			} else {
 				o.MsgCh <- Message{rn.Hashcode().(string), Success, nil}
 			}
 		} else {
-			s = node.Execute(*o)
+			s = node.Execute(o)
 		}
 	}
 	if s != nil {

--- a/pkg/engine/operation/apply_test.go
+++ b/pkg/engine/operation/apply_test.go
@@ -59,7 +59,7 @@ func TestOperation_Apply(t *testing.T) {
 		CtxResourceIndex        map[string]*states.ResourceState
 		PriorStateResourceIndex map[string]*states.ResourceState
 		StateResourceIndex      map[string]*states.ResourceState
-		ChangeStepMap           map[string]*ChangeStep
+		Order                   *ChangeOrder
 		Runtime                 runtime.Runtime
 		MsgCh                   chan Message
 		resultState             *states.State
@@ -137,14 +137,14 @@ func TestOperation_Apply(t *testing.T) {
 				CtxResourceIndex:        tt.fields.CtxResourceIndex,
 				PriorStateResourceIndex: tt.fields.PriorStateResourceIndex,
 				StateResourceIndex:      tt.fields.StateResourceIndex,
-				ChangeStepMap:           tt.fields.ChangeStepMap,
+				Order:                   tt.fields.Order,
 				Runtime:                 tt.fields.Runtime,
 				MsgCh:                   tt.fields.MsgCh,
 				resultState:             tt.fields.resultState,
 				lock:                    tt.fields.lock,
 			}
 
-			monkey.Patch((*ResourceNode).Execute, func(rn *ResourceNode, operation Operation) status.Status {
+			monkey.Patch((*ResourceNode).Execute, func(rn *ResourceNode, operation *Operation) status.Status {
 				o.resultState = rs
 				return nil
 			})

--- a/pkg/engine/operation/change.go
+++ b/pkg/engine/operation/change.go
@@ -77,27 +77,33 @@ var (
 )
 
 type Changes struct {
-	ChangeSteps map[string]*ChangeStep
-	project     *projectstack.Project // the project of current changes
-	stack       *projectstack.Stack   // the stack of current changes
+	*ChangeOrder
+	project *projectstack.Project // the project of current changes
+	stack   *projectstack.Stack   // the stack of current changes
 }
 
-func NewChanges(p *projectstack.Project, s *projectstack.Stack, steps map[string]*ChangeStep) *Changes {
+type ChangeOrder struct {
+	StepKeys    []string
+	ChangeSteps map[string]*ChangeStep
+}
+
+func NewChanges(p *projectstack.Project, s *projectstack.Stack, order *ChangeOrder) *Changes {
 	return &Changes{
-		ChangeSteps: steps,
+		ChangeOrder: order,
 		project:     p,
 		stack:       s,
 	}
 }
 
-func (p *Changes) Get(key string) *ChangeStep {
-	return p.ChangeSteps[key]
+func (o *ChangeOrder) Get(key string) *ChangeStep {
+	return o.ChangeSteps[key]
 }
 
-func (p *Changes) Values(filters ...ChangeStepFilterFunc) []*ChangeStep {
-	result := []*ChangeStep{}
+func (o *ChangeOrder) Values(filters ...ChangeStepFilterFunc) []*ChangeStep {
+	var result []*ChangeStep
 
-	for _, v := range p.ChangeSteps {
+	for _, key := range o.StepKeys {
+		v := o.ChangeSteps[key]
 		// Deal filters
 		var i int
 		for i = 0; i < len(filters); i++ {
@@ -124,10 +130,11 @@ func (p *Changes) Project() *projectstack.Project {
 	return p.project
 }
 
-func (p *Changes) Diffs() string {
+func (o *ChangeOrder) Diffs() string {
 	buf := bytes.NewBufferString("")
 
-	for _, step := range p.ChangeSteps {
+	for _, key := range o.StepKeys {
+		step := o.ChangeSteps[key]
 		// Generate diff report
 		diffString, err := step.Diff()
 		if err != nil {
@@ -148,7 +155,7 @@ func (p *Changes) Summary() {
 
 	for i, step := range p.Values() {
 		itemPrefix := " * ├─"
-		if i == len(p.ChangeSteps)-1 {
+		if i == len(p.StepKeys)-1 {
 			itemPrefix = " * └─"
 		}
 
@@ -158,19 +165,20 @@ func (p *Changes) Summary() {
 	pterm.DefaultTable.WithHasHeader().
 		// WithBoxed(true).
 		WithHeaderStyle(&pterm.ThemeDefault.TableHeaderStyle).
-		WithRightAlignment(true).
+		WithLeftAlignment(true).
 		WithSeparator("  ").
 		WithData(tableData).
 		Render()
 	pterm.Println() // Blank line
 }
 
-func (p *Changes) PromptDetails() (string, error) {
+func (o *ChangeOrder) PromptDetails() (string, error) {
 	// Prepare the selects
 	options := []string{"all"}
 	optionMaps := map[string]string{"all": "all"}
 
-	for _, cs := range p.ChangeSteps {
+	for _, key := range o.StepKeys {
+		cs := o.ChangeSteps[key]
 		humanKeyAndOp := pterm.Sprintf("%s %s", cs.ID, pretty.Gray(cs.Action.String()))
 		options = append(options, humanKeyAndOp)
 		optionMaps[humanKeyAndOp] = cs.ID
@@ -194,13 +202,13 @@ func (p *Changes) PromptDetails() (string, error) {
 	return optionMaps[input], nil
 }
 
-func (p *Changes) OutputDiff(target string) {
+func (o *ChangeOrder) OutputDiff(target string) {
 	switch target {
 	case "all":
-		fmt.Println(p.Diffs())
+		fmt.Println(o.Diffs())
 	default:
 		rinID := target
-		if cs, ok := p.ChangeSteps[rinID]; ok {
+		if cs, ok := o.ChangeSteps[rinID]; ok {
 			diffString, err := cs.Diff()
 			if err != nil {
 				log.Error("failed to output specify diff with rinID: %s, err: %v", rinID, err)

--- a/pkg/engine/operation/destory.go
+++ b/pkg/engine/operation/destory.go
@@ -72,7 +72,6 @@ func (o *Operation) Destroy(request *DestroyRequest) (st status.Status) {
 			CtxResourceIndex:        map[string]*states.ResourceState{},
 			PriorStateResourceIndex: priorStateResourceIndex,
 			StateResourceIndex:      priorStateResourceIndex,
-			ChangeStepMap:           o.ChangeStepMap,
 			Runtime:                 o.Runtime,
 			MsgCh:                   o.MsgCh,
 			resultState:             resultState,
@@ -80,7 +79,7 @@ func (o *Operation) Destroy(request *DestroyRequest) (st status.Status) {
 		},
 	}
 
-	w := dag.Walker{Callback: do.applyWalkFun}
+	w := &dag.Walker{Callback: do.applyWalkFun}
 	w.Update(graph)
 	// Wait
 	if diags := w.Wait(); diags.HasErrors() {

--- a/pkg/engine/operation/destory_test.go
+++ b/pkg/engine/operation/destory_test.go
@@ -48,7 +48,7 @@ func TestOperation_Destroy(t *testing.T) {
 
 	t.Run("destroy success", func(t *testing.T) {
 		defer monkey.UnpatchAll()
-		monkey.Patch((*ResourceNode).Execute, func(rn *ResourceNode, operation Operation) status.Status {
+		monkey.Patch((*ResourceNode).Execute, func(rn *ResourceNode, operation *Operation) status.Status {
 			return nil
 		})
 		o.MsgCh = make(chan Message, 1)
@@ -59,7 +59,7 @@ func TestOperation_Destroy(t *testing.T) {
 
 	t.Run("destroy failed", func(t *testing.T) {
 		defer monkey.UnpatchAll()
-		monkey.Patch((*ResourceNode).Execute, func(rn *ResourceNode, operation Operation) status.Status {
+		monkey.Patch((*ResourceNode).Execute, func(rn *ResourceNode, operation *Operation) status.Status {
 			return status.NewErrorStatus(errors.New("mock error"))
 		})
 

--- a/pkg/engine/operation/executable_node.go
+++ b/pkg/engine/operation/executable_node.go
@@ -3,5 +3,5 @@ package operation
 import "kusionstack.io/kusion/pkg/status"
 
 type ExecutableNode interface {
-	Execute(operation Operation) status.Status
+	Execute(operation *Operation) status.Status
 }

--- a/pkg/engine/operation/operation.go
+++ b/pkg/engine/operation/operation.go
@@ -24,11 +24,12 @@ type Operation struct {
 	PriorStateResourceIndex map[string]*states.ResourceState
 	// StateResourceIndex represents resources that will be saved in states.StateStorage
 	StateResourceIndex map[string]*states.ResourceState
-	ChangeStepMap      map[string]*ChangeStep
-	Runtime            runtime.Runtime
-	MsgCh              chan Message
-	resultState        *states.State
-	lock               *sync.Mutex
+	// Order contains id to action of resource node in preview order
+	Order       *ChangeOrder
+	Runtime     runtime.Runtime
+	MsgCh       chan Message
+	resultState *states.State
+	lock        *sync.Mutex
 }
 
 type Message struct {

--- a/pkg/engine/operation/preview.go
+++ b/pkg/engine/operation/preview.go
@@ -22,7 +22,7 @@ type PreviewRequest struct {
 }
 
 type PreviewResponse struct {
-	ChangeSteps map[string]*ChangeStep
+	Order *ChangeOrder
 }
 
 func (o *Operation) Preview(request *PreviewRequest, operation Type) (rsp *PreviewResponse, s status.Status) {
@@ -77,20 +77,20 @@ func (o *Operation) Preview(request *PreviewRequest, operation Type) (rsp *Previ
 			CtxResourceIndex:        map[string]*states.ResourceState{},
 			PriorStateResourceIndex: priorStateResourceIndex,
 			StateResourceIndex:      priorStateResourceIndex,
-			ChangeStepMap:           o.ChangeStepMap,
+			Order:                   o.Order,
 			resultState:             resultState,
 			lock:                    &sync.Mutex{},
 		},
 	}
 
-	w := dag.Walker{Callback: previewOperation.previewWalkFun}
+	w := &dag.Walker{Callback: previewOperation.previewWalkFun}
 	w.Update(graph)
 	// Wait
 	if diags := w.Wait(); diags.HasErrors() {
 		return nil, status.NewErrorStatus(diags.Err())
 	}
 
-	return &PreviewResponse{ChangeSteps: previewOperation.ChangeStepMap}, nil
+	return &PreviewResponse{Order: previewOperation.Order}, nil
 }
 
 func (po *PreviewOperation) previewWalkFun(v dag.Vertex) (diags tfdiags.Diagnostics) {
@@ -116,7 +116,7 @@ func (po *PreviewOperation) previewWalkFun(v dag.Vertex) (diags tfdiags.Diagnost
 	}()
 
 	if node, ok := v.(ExecutableNode); ok {
-		s = node.Execute(po.Operation)
+		s = node.Execute(&po.Operation)
 		if status.IsErr(s) {
 			diags = diags.Append(fmt.Errorf("node execute failed, status: %v", s))
 			return diags

--- a/pkg/engine/operation/preview_test.go
+++ b/pkg/engine/operation/preview_test.go
@@ -38,7 +38,7 @@ func TestOperation_Preview(t *testing.T) {
 		CtxResourceIndex        map[string]*states.ResourceState
 		PriorStateResourceIndex map[string]*states.ResourceState
 		StateResourceIndex      map[string]*states.ResourceState
-		ChangeStepMap           map[string]*ChangeStep
+		Order                   *ChangeOrder
 		Runtime                 runtime.Runtime
 		MsgCh                   chan Message
 		resultState             *states.State
@@ -58,9 +58,9 @@ func TestOperation_Preview(t *testing.T) {
 		{
 			name: "success-when-apply",
 			fields: fields{
-				Runtime:       &runtime.KubernetesRuntime{},
-				StateStorage:  &states.FileSystemState{Path: states.KusionState},
-				ChangeStepMap: map[string]*ChangeStep{},
+				Runtime:      &runtime.KubernetesRuntime{},
+				StateStorage: &states.FileSystemState{Path: states.KusionState},
+				Order:        &ChangeOrder{StepKeys: []string{}, ChangeSteps: map[string]*ChangeStep{}},
 			},
 			args: args{
 				request: &PreviewRequest{
@@ -79,12 +79,15 @@ func TestOperation_Preview(t *testing.T) {
 				operation: Apply,
 			},
 			wantRsp: &PreviewResponse{
-				ChangeSteps: map[string]*ChangeStep{
-					"fake-id": {
-						ID:     "fake-id",
-						Action: Create,
-						Old:    (*states.ResourceState)(nil),
-						New:    &FakeResourceState,
+				Order: &ChangeOrder{
+					StepKeys: []string{"fake-id"},
+					ChangeSteps: map[string]*ChangeStep{
+						"fake-id": {
+							ID:     "fake-id",
+							Action: Create,
+							Old:    (*states.ResourceState)(nil),
+							New:    &FakeResourceState,
+						},
 					},
 				},
 			},
@@ -93,9 +96,9 @@ func TestOperation_Preview(t *testing.T) {
 		{
 			name: "success-when-destroy",
 			fields: fields{
-				Runtime:       &runtime.KubernetesRuntime{},
-				StateStorage:  &states.FileSystemState{Path: states.KusionState},
-				ChangeStepMap: map[string]*ChangeStep{},
+				Runtime:      &runtime.KubernetesRuntime{},
+				StateStorage: &states.FileSystemState{Path: states.KusionState},
+				Order:        &ChangeOrder{},
 			},
 			args: args{
 				request: &PreviewRequest{
@@ -114,12 +117,15 @@ func TestOperation_Preview(t *testing.T) {
 				operation: Destroy,
 			},
 			wantRsp: &PreviewResponse{
-				ChangeSteps: map[string]*ChangeStep{
-					"fake-id": {
-						ID:     "fake-id",
-						Action: Delete,
-						Old:    &FakeResourceState,
-						New:    (*states.ResourceState)(nil),
+				Order: &ChangeOrder{
+					StepKeys: []string{"fake-id"},
+					ChangeSteps: map[string]*ChangeStep{
+						"fake-id": {
+							ID:     "fake-id",
+							Action: Delete,
+							Old:    &FakeResourceState,
+							New:    (*states.ResourceState)(nil),
+						},
 					},
 				},
 			},
@@ -128,9 +134,9 @@ func TestOperation_Preview(t *testing.T) {
 		{
 			name: "fail-because-empty-manifest",
 			fields: fields{
-				Runtime:       &runtime.KubernetesRuntime{},
-				StateStorage:  &states.FileSystemState{Path: states.KusionState},
-				ChangeStepMap: map[string]*ChangeStep{},
+				Runtime:      &runtime.KubernetesRuntime{},
+				StateStorage: &states.FileSystemState{Path: states.KusionState},
+				Order:        &ChangeOrder{},
 			},
 			args: args{
 				request: &PreviewRequest{
@@ -146,9 +152,9 @@ func TestOperation_Preview(t *testing.T) {
 		{
 			name: "fail-because-nonexistent-id",
 			fields: fields{
-				Runtime:       &runtime.KubernetesRuntime{},
-				StateStorage:  &states.FileSystemState{Path: states.KusionState},
-				ChangeStepMap: map[string]*ChangeStep{},
+				Runtime:      &runtime.KubernetesRuntime{},
+				StateStorage: &states.FileSystemState{Path: states.KusionState},
+				Order:        &ChangeOrder{},
 			},
 			args: args{
 				request: &PreviewRequest{
@@ -183,7 +189,7 @@ func TestOperation_Preview(t *testing.T) {
 				CtxResourceIndex:        tt.fields.CtxResourceIndex,
 				PriorStateResourceIndex: tt.fields.PriorStateResourceIndex,
 				StateResourceIndex:      tt.fields.StateResourceIndex,
-				ChangeStepMap:           tt.fields.ChangeStepMap,
+				Order:                   tt.fields.Order,
 				Runtime:                 tt.fields.Runtime,
 				MsgCh:                   tt.fields.MsgCh,
 				resultState:             tt.fields.resultState,

--- a/pkg/engine/operation/resource_node_test.go
+++ b/pkg/engine/operation/resource_node_test.go
@@ -174,7 +174,7 @@ func TestResourceNode_Execute(t *testing.T) {
 				})
 			defer monkey.UnpatchAll()
 
-			assert.Equalf(t, tt.want, rn.Execute(tt.args.operation), "Execute(%v)", tt.args.operation)
+			assert.Equalf(t, tt.want, rn.Execute(&tt.args.operation), "Execute(%v)", tt.args.operation)
 		})
 	}
 }

--- a/pkg/kusionctl/cmd/apply/options.go
+++ b/pkg/kusionctl/cmd/apply/options.go
@@ -141,9 +141,9 @@ func preview(o *ApplyOptions, planResources *manifest.Manifest,
 
 	pc := &operation.PreviewOperation{
 		Operation: operation.Operation{
-			Runtime:       kubernetesRuntime,
-			StateStorage:  &states.FileSystemState{Path: filepath.Join(o.CompileOptions.WorkDir, states.KusionState)},
-			ChangeStepMap: map[string]*operation.ChangeStep{},
+			Runtime:      kubernetesRuntime,
+			StateStorage: &states.FileSystemState{Path: filepath.Join(o.WorkDir, states.KusionState)},
+			Order:        &operation.ChangeOrder{StepKeys: []string{}, ChangeSteps: map[string]*operation.ChangeStep{}},
 		},
 	}
 
@@ -162,7 +162,7 @@ func preview(o *ApplyOptions, planResources *manifest.Manifest,
 		return nil, fmt.Errorf("preview failed.\n%s", s.String())
 	}
 
-	return operation.NewChanges(project, stack, rsp.ChangeSteps), nil
+	return operation.NewChanges(project, stack, rsp.Order), nil
 }
 
 func apply(o *ApplyOptions, planResources *manifest.Manifest, changes *operation.Changes) error {
@@ -174,10 +174,9 @@ func apply(o *ApplyOptions, planResources *manifest.Manifest, changes *operation
 
 	ac := &operation.ApplyOperation{
 		Operation: operation.Operation{
-			Runtime:       kubernetesRuntime,
-			StateStorage:  &states.FileSystemState{Path: filepath.Join(o.CompileOptions.WorkDir, states.KusionState)},
-			MsgCh:         make(chan operation.Message),
-			ChangeStepMap: map[string]*operation.ChangeStep{},
+			Runtime:      kubernetesRuntime,
+			StateStorage: &states.FileSystemState{Path: filepath.Join(o.WorkDir, states.KusionState)},
+			MsgCh:        make(chan operation.Message),
 		},
 	}
 
@@ -185,7 +184,7 @@ func apply(o *ApplyOptions, planResources *manifest.Manifest, changes *operation
 	var ls lineSummary
 
 	// progress bar, print dag walk detail
-	progressbar, err := pterm.DefaultProgressbar.WithTotal(len(changes.ChangeSteps)).Start()
+	progressbar, err := pterm.DefaultProgressbar.WithTotal(len(changes.StepKeys)).Start()
 	if err != nil {
 		return err
 	}

--- a/pkg/kusionctl/cmd/apply/options_test.go
+++ b/pkg/kusionctl/cmd/apply/options_test.go
@@ -151,24 +151,27 @@ func mockOperationPreview() {
 	monkey.Patch((*operation.Operation).Preview,
 		func(*operation.Operation, *operation.PreviewRequest, operation.Type) (rsp *operation.PreviewResponse, s status.Status) {
 			return &operation.PreviewResponse{
-				ChangeSteps: map[string]*operation.ChangeStep{
-					sa1.ID: {
-						ID:     sa1.ID,
-						Action: operation.Create,
-						Old:    nil,
-						New:    &sa1,
-					},
-					sa2.ID: {
-						ID:     sa2.ID,
-						Action: operation.UnChange,
-						Old:    &sa2,
-						New:    &sa2,
-					},
-					sa3.ID: {
-						ID:     sa3.ID,
-						Action: operation.Undefined,
-						Old:    &sa3,
-						New:    &sa1,
+				Order: &operation.ChangeOrder{
+					StepKeys: []string{sa1.ID, sa2.ID, sa3.ID},
+					ChangeSteps: map[string]*operation.ChangeStep{
+						sa1.ID: {
+							ID:     sa1.ID,
+							Action: operation.Create,
+							Old:    nil,
+							New:    &sa1,
+						},
+						sa2.ID: {
+							ID:     sa2.ID,
+							Action: operation.UnChange,
+							Old:    &sa2,
+							New:    &sa2,
+						},
+						sa3.ID: {
+							ID:     sa3.ID,
+							Action: operation.Undefined,
+							Old:    &sa3,
+							New:    &sa1,
+						},
 					},
 				},
 			}, nil
@@ -209,15 +212,18 @@ func Test_apply(t *testing.T) {
 		mockNewKubernetesRuntime()
 
 		planResources := &manifest.Manifest{Resources: []states.ResourceState{sa1}}
-		changeSteps := map[string]*operation.ChangeStep{
-			sa1.ID: {
-				ID:     sa1.ID,
-				Action: operation.Create,
-				Old:    nil,
-				New:    sa1,
+		order := &operation.ChangeOrder{
+			StepKeys: []string{sa1.ID},
+			ChangeSteps: map[string]*operation.ChangeStep{
+				sa1.ID: {
+					ID:     sa1.ID,
+					Action: operation.Create,
+					Old:    nil,
+					New:    sa1,
+				},
 			},
 		}
-		changes := operation.NewChanges(project, stack, changeSteps)
+		changes := operation.NewChanges(project, stack, order)
 		o := NewApplyOptions()
 		o.DryRun = true
 		err := apply(o, planResources, changes)
@@ -230,21 +236,24 @@ func Test_apply(t *testing.T) {
 
 		o := NewApplyOptions()
 		planResources := &manifest.Manifest{Resources: []states.ResourceState{sa1, sa2}}
-		changeSteps := map[string]*operation.ChangeStep{
-			sa1.ID: {
-				ID:     sa1.ID,
-				Action: operation.Create,
-				Old:    nil,
-				New:    &sa1,
-			},
-			sa2.ID: {
-				ID:     sa2.ID,
-				Action: operation.UnChange,
-				Old:    &sa2,
-				New:    &sa2,
+		order := &operation.ChangeOrder{
+			StepKeys: []string{sa1.ID, sa2.ID},
+			ChangeSteps: map[string]*operation.ChangeStep{
+				sa1.ID: {
+					ID:     sa1.ID,
+					Action: operation.Create,
+					Old:    nil,
+					New:    &sa1,
+				},
+				sa2.ID: {
+					ID:     sa2.ID,
+					Action: operation.UnChange,
+					Old:    &sa2,
+					New:    &sa2,
+				},
 			},
 		}
-		changes := operation.NewChanges(project, stack, changeSteps)
+		changes := operation.NewChanges(project, stack, order)
 
 		err := apply(o, planResources, changes)
 		assert.Nil(t, err)
@@ -256,15 +265,18 @@ func Test_apply(t *testing.T) {
 
 		o := NewApplyOptions()
 		planResources := &manifest.Manifest{Resources: []states.ResourceState{sa1}}
-		changeSteps := map[string]*operation.ChangeStep{
-			sa1.ID: {
-				ID:     sa1.ID,
-				Action: operation.Create,
-				Old:    nil,
-				New:    &sa1,
+		order := &operation.ChangeOrder{
+			StepKeys: []string{sa1.ID},
+			ChangeSteps: map[string]*operation.ChangeStep{
+				sa1.ID: {
+					ID:     sa1.ID,
+					Action: operation.Create,
+					Old:    nil,
+					New:    &sa1,
+				},
 			},
 		}
-		changes := operation.NewChanges(project, stack, changeSteps)
+		changes := operation.NewChanges(project, stack, order)
 
 		err := apply(o, planResources, changes)
 		assert.NotNil(t, err)

--- a/pkg/kusionctl/cmd/destroy/options.go
+++ b/pkg/kusionctl/cmd/destroy/options.go
@@ -127,9 +127,9 @@ func (o *DestroyOptions) preview(planResources *manifest.Manifest,
 
 	pc := &operation.PreviewOperation{
 		Operation: operation.Operation{
-			Runtime:       kubernetesRuntime,
-			StateStorage:  &states.FileSystemState{Path: filepath.Join(o.CompileOptions.WorkDir, states.KusionState)},
-			ChangeStepMap: map[string]*operation.ChangeStep{},
+			Runtime:      kubernetesRuntime,
+			StateStorage: &states.FileSystemState{Path: filepath.Join(o.WorkDir, states.KusionState)},
+			Order:        &operation.ChangeOrder{StepKeys: []string{}, ChangeSteps: map[string]*operation.ChangeStep{}},
 		},
 	}
 
@@ -148,7 +148,7 @@ func (o *DestroyOptions) preview(planResources *manifest.Manifest,
 		return nil, fmt.Errorf("preview failed, status: %v", s)
 	}
 
-	return operation.NewChanges(project, stack, rsp.ChangeSteps), nil
+	return operation.NewChanges(project, stack, rsp.Order), nil
 }
 
 func (o *DestroyOptions) destroy(planResources *manifest.Manifest, changes *operation.Changes) error {
@@ -160,10 +160,9 @@ func (o *DestroyOptions) destroy(planResources *manifest.Manifest, changes *oper
 
 	do := &operation.DestroyOperation{
 		Operation: operation.Operation{
-			Runtime:       kubernetesRuntime,
-			StateStorage:  &states.FileSystemState{Path: filepath.Join(o.CompileOptions.WorkDir, states.KusionState)},
-			MsgCh:         make(chan operation.Message),
-			ChangeStepMap: map[string]*operation.ChangeStep{},
+			Runtime:      kubernetesRuntime,
+			StateStorage: &states.FileSystemState{Path: filepath.Join(o.WorkDir, states.KusionState)},
+			MsgCh:        make(chan operation.Message),
 		},
 	}
 
@@ -171,7 +170,7 @@ func (o *DestroyOptions) destroy(planResources *manifest.Manifest, changes *oper
 	var deleted int
 
 	// progress bar, print dag walk detail
-	progressbar, err := pterm.DefaultProgressbar.WithTotal(len(changes.ChangeSteps)).Start()
+	progressbar, err := pterm.DefaultProgressbar.WithTotal(len(changes.StepKeys)).Start()
 	if err != nil {
 		return err
 	}

--- a/pkg/kusionctl/cmd/destroy/options_test.go
+++ b/pkg/kusionctl/cmd/destroy/options_test.go
@@ -143,12 +143,15 @@ func mockOperationPreview() {
 	monkey.Patch((*operation.Operation).Preview,
 		func(*operation.Operation, *operation.PreviewRequest, operation.Type) (rsp *operation.PreviewResponse, s status.Status) {
 			return &operation.PreviewResponse{
-				ChangeSteps: map[string]*operation.ChangeStep{
-					sa1.ID: {
-						ID:     sa1.ID,
-						Action: operation.Delete,
-						Old:    &sa1,
-						New:    nil,
+				Order: &operation.ChangeOrder{
+					StepKeys: []string{sa1.ID},
+					ChangeSteps: map[string]*operation.ChangeStep{
+						sa1.ID: {
+							ID:     sa1.ID,
+							Action: operation.Delete,
+							Old:    &sa1,
+							New:    nil,
+						},
 					},
 				},
 			}, nil
@@ -190,21 +193,24 @@ func Test_destroy(t *testing.T) {
 
 		o := NewDestroyOptions()
 		planResources := &manifest.Manifest{Resources: []states.ResourceState{sa2}}
-		changeSteps := map[string]*operation.ChangeStep{
-			sa1.ID: {
-				ID:     sa1.ID,
-				Action: operation.Delete,
-				Old:    &sa1,
-				New:    nil,
-			},
-			sa2.ID: {
-				ID:     sa2.ID,
-				Action: operation.UnChange,
-				Old:    &sa2,
-				New:    &sa2,
+		order := &operation.ChangeOrder{
+			StepKeys: []string{sa1.ID, sa2.ID},
+			ChangeSteps: map[string]*operation.ChangeStep{
+				sa1.ID: {
+					ID:     sa1.ID,
+					Action: operation.Delete,
+					Old:    &sa1,
+					New:    nil,
+				},
+				sa2.ID: {
+					ID:     sa2.ID,
+					Action: operation.UnChange,
+					Old:    &sa2,
+					New:    &sa2,
+				},
 			},
 		}
-		changes := operation.NewChanges(project, stack, changeSteps)
+		changes := operation.NewChanges(project, stack, order)
 
 		err := o.destroy(planResources, changes)
 		assert.Nil(t, err)
@@ -216,15 +222,18 @@ func Test_destroy(t *testing.T) {
 
 		o := NewDestroyOptions()
 		planResources := &manifest.Manifest{Resources: []states.ResourceState{sa1}}
-		changeSteps := map[string]*operation.ChangeStep{
-			sa1.ID: {
-				ID:     sa1.ID,
-				Action: operation.Delete,
-				Old:    &sa1,
-				New:    nil,
+		order := &operation.ChangeOrder{
+			StepKeys: []string{sa1.ID},
+			ChangeSteps: map[string]*operation.ChangeStep{
+				sa1.ID: {
+					ID:     sa1.ID,
+					Action: operation.Delete,
+					Old:    &sa1,
+					New:    nil,
+				},
 			},
 		}
-		changes := operation.NewChanges(project, stack, changeSteps)
+		changes := operation.NewChanges(project, stack, order)
 
 		err := o.destroy(planResources, changes)
 		assert.NotNil(t, err)


### PR DESCRIPTION
When `kusion apply` in preview stage, the previewed table not always the same.

## Root Cause

- after pre-dependent nodes finished, these downEdges are executing in paralyzing, so we cannot ensure the key returned from resource_node.execute() are alway the same.
- map traversing(node id -> action), it is originally disordered.

## Current Fix

- ignore concurrent execution of peer nodes
- save node id in sequence, keep order by traversing slice instead of map