### PR TITLE
Feature: support kusion deps subcommand

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	k8s.io/component-base v0.21.2
 	k8s.io/kubectl v0.21.2
 	kusionstack.io/kcl-plugin v0.4.1-alpha2
-	kusionstack.io/kclvm-go v0.4.2-alpha1
+	kusionstack.io/kclvm-go v0.4.2-alpha2
 	sigs.k8s.io/kustomize/api v0.8.11
 	sigs.k8s.io/kustomize/kustomize/v4 v4.1.2
 	sigs.k8s.io/kustomize/kyaml v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
+github.com/deckarep/golang-set v1.8.0 h1:sk9/l/KqpunDwP7pSjUg0keiOOLEnOBHzykLrsPppp4=
+github.com/deckarep/golang-set v1.8.0/go.mod h1:5nI87KwE7wgsBU1F4GKAw2Qod7p5kyS383rP6+o6qqo=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/didi/gendry v1.7.0 h1:dFR6+TVCnbjvLfNiGN53xInG/C5HqG7u0gfnkF5J/Vo=
@@ -1392,10 +1394,8 @@ k8s.io/utils v0.0.0-20201110183641-67b214c5f920 h1:CbnUZsM497iRC5QMVkHwyl8s2tB3g
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 kusionstack.io/kcl-plugin v0.4.1-alpha2 h1:m43JJhpJSjl/Q3FqghJf5dRIwdXsrJeKxrHhgqLJqbA=
 kusionstack.io/kcl-plugin v0.4.1-alpha2/go.mod h1:VgB7qXVbDGWFOh/qb/yXf75+UrliP5EPXOQUDqBCdAQ=
-kusionstack.io/kclvm-go v0.4.1-alpha9 h1:aR9VU1Qnnbu3F5StnOgHB/MJvQwMjT+d9QCZy+oTgyQ=
-kusionstack.io/kclvm-go v0.4.1-alpha9/go.mod h1:cxsYIWWMiDk7mwWJMm6H9kzNNtoIpOQHgzJBZvHThzo=
-kusionstack.io/kclvm-go v0.4.2-alpha1 h1:jB3xL1NjQh3djzkVOgAAiMqDRV51cil4xK+KlsSnTlU=
-kusionstack.io/kclvm-go v0.4.2-alpha1/go.mod h1:cxsYIWWMiDk7mwWJMm6H9kzNNtoIpOQHgzJBZvHThzo=
+kusionstack.io/kclvm-go v0.4.2-alpha2 h1:D/+kky/pzlay9K4BOrgmnFpuoBjeC2v7mfRlmQjs/rc=
+kusionstack.io/kclvm-go v0.4.2-alpha2/go.mod h1:LKGVud6Ch0dLLACwPqZQyU4E+NkLAXzveJFQWVb5Pbk=
 pgregory.net/rapid v0.4.7/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=

--- a/pkg/kusionctl/cmd/cmd.go
+++ b/pkg/kusionctl/cmd/cmd.go
@@ -11,6 +11,7 @@ import (
 	"kusionstack.io/kusion/pkg/kusionctl/cmd/apply"
 	"kusionstack.io/kusion/pkg/kusionctl/cmd/check"
 	"kusionstack.io/kusion/pkg/kusionctl/cmd/compile"
+	"kusionstack.io/kusion/pkg/kusionctl/cmd/deps"
 	"kusionstack.io/kusion/pkg/kusionctl/cmd/destroy"
 	"kusionstack.io/kusion/pkg/kusionctl/cmd/env"
 	cmdinit "kusionstack.io/kusion/pkg/kusionctl/cmd/init"
@@ -74,6 +75,7 @@ func NewKusionctlCmd(in io.Reader, out, err io.Writer) *cobra.Command {
 				compile.NewCmdCompile(),
 				check.NewCmdCheck(),
 				ls.NewCmdLs(),
+				deps.NewCmdDeps(),
 			},
 		},
 		{

--- a/pkg/kusionctl/cmd/deps/deps.go
+++ b/pkg/kusionctl/cmd/deps/deps.go
@@ -1,0 +1,60 @@
+package deps
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	"kusionstack.io/kusion/pkg/kusionctl/cmd/util"
+	"kusionstack.io/kusion/pkg/util/i18n"
+)
+
+var (
+	depsShort = "Show KCL file dependency information"
+
+	depsLong = `
+		Show the KCL file dependency information in the current directory or the specified workdir. 
+        By default, it will list all the KCL files that are dependent on the given package path.`
+
+	depsExample = `
+		# List all the KCL files that are dependent by the given focus paths
+        kusion deps --focus path/to/focus1 --focus path/to/focus2
+
+		# List all the projects that depend on the given focus paths
+		kusion deps --direct down --focus path/to/focus1 --focus path/to/focus2
+
+		# List all the stacks that depend on the given focus paths
+		kusion deps --direct down --focus path/to/focus1 --focus path/to/focus2 --only stack
+
+		# List all the projects that depend on the given focus paths, ignoring some paths from entrance files in each stack
+		kusion deps --direct down --focus path/to/focus1 --focus path/to/focus2 --ignore path/to/ignore`
+)
+
+func NewCmdDeps() *cobra.Command {
+	o := NewDepsOptions()
+
+	cmd := &cobra.Command{
+		Use:     "deps [WORKDIR]",
+		Short:   i18n.T(depsShort),
+		Long:    templates.LongDesc(i18n.T(depsLong)),
+		Example: templates.Examples(i18n.T(depsExample)),
+		Args:    cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) (err error) {
+			defer util.RecoverErr(&err)
+			o.Complete(args)
+			util.CheckErr(o.Validate())
+			util.CheckErr(o.Run())
+			return
+		},
+	}
+
+	cmd.Flags().StringVar(&o.Direct, "direct", "up",
+		i18n.T("the inspect direct of the dependency information. Valid values: up, down. Defaults to up"))
+	cmd.Flags().StringSliceVar(&o.Focus, "focus", nil,
+		i18n.T("the paths to focus on to inspect. It cannot be empty and each path needs to be a valid relative path from the workdir"))
+	cmd.Flags().StringVar(&o.Only, "only", "project",
+		i18n.T("when direct is set to \"down\", \"only\" means only the downstream project/stack list will be output. Valid values: project, stack. Defaults to project"))
+	cmd.Flags().StringSliceVar(&o.Ignore, "ignore", nil,
+		i18n.T("the file paths to ignore when filtering the affected stacks/projects. Each path needs to be a valid relative path from the workdir. If not set, no paths will be ignored."))
+
+	return cmd
+}

--- a/pkg/kusionctl/cmd/deps/options.go
+++ b/pkg/kusionctl/cmd/deps/options.go
@@ -1,0 +1,182 @@
+package deps
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	kcl "kusionstack.io/kclvm-go"
+	"kusionstack.io/kclvm-go/pkg/tools/list"
+	"kusionstack.io/kusion/pkg/projectstack"
+)
+
+type DepsOptions struct {
+	workDir string
+	Direct  string
+	Focus   []string
+	Only    string
+	Ignore  []string
+}
+
+func NewDepsOptions() *DepsOptions {
+	return &DepsOptions{}
+}
+
+func (o *DepsOptions) Complete(args []string) {
+	if len(args) > 0 {
+		o.workDir = args[0]
+	}
+
+	if o.workDir == "" {
+		o.workDir, _ = os.Getwd()
+	}
+}
+
+func (o *DepsOptions) Validate() error {
+	if o.Only != "project" && o.Only != "stack" {
+		return fmt.Errorf("invalid output downstream type. supported types: project, stack")
+	}
+
+	if o.Direct != "down" && o.Direct != "up" {
+		return fmt.Errorf("invalid output direction of the dependency inspection. supported directions: up, down")
+	}
+
+	if _, err := os.Stat(o.workDir); err != nil {
+		return fmt.Errorf("invalid work dir: %s", err)
+	}
+
+	if o.Focus == nil || len(o.Focus) == 0 {
+		return fmt.Errorf("invalid focus paths. cannot be empty")
+	}
+
+	for _, focus := range o.Focus {
+		if _, err := os.Stat(filepath.Join(o.workDir, focus)); err != nil {
+			return fmt.Errorf("invalid focus path. need to be valid relative path from the workdir: %s", err)
+		}
+	}
+
+	for _, ignore := range o.Ignore {
+		if _, err := os.Stat(filepath.Join(o.workDir, ignore)); err != nil {
+			return fmt.Errorf("invalid ignore path. need to be valid relative path from the workdir: %s", err)
+		}
+	}
+	return nil
+}
+
+func (o *DepsOptions) Run() error {
+	workDir, err := filepath.Abs(o.workDir)
+	if err != nil {
+		return err
+	}
+	o.workDir = workDir
+	switch o.Direct {
+	case "up":
+		depsFiles, err := list.ListUpStreamFiles(o.workDir, &list.DepOption{Files: o.Focus})
+		if err != nil {
+			return err
+		}
+		for _, v := range depsFiles {
+			fmt.Println(v)
+		}
+		return nil
+	case "down":
+		projects, err := projectstack.FindAllProjectsFrom(o.workDir)
+		if err != nil {
+			return err
+		}
+		file2StackMap := map[string][]string{}
+		file2ProjMap := map[string][]string{}
+		entranceFiles := []string{}
+		ignoreMap := map[string]bool{}
+		for _, ignore := range o.Ignore {
+			ignoreMap[ignore] = true
+		}
+		for _, project := range projects {
+			relProjPath, err := filepath.Rel(o.workDir, project.GetPath())
+			if err != nil {
+				return err
+			}
+			for _, stack := range project.Stacks {
+				relStackPath, err := filepath.Rel(o.workDir, stack.GetPath())
+				if err != nil {
+					return err
+				}
+				opt := kcl.WithSettings(filepath.Join(stack.GetPath(), projectstack.KclFile))
+				for _, entranceFile := range opt.KFilenameList {
+					relPath, err := filepath.Rel(o.workDir, entranceFile)
+					if err != nil {
+						return err
+					}
+					if _, ok := ignoreMap[relPath]; ok {
+						continue
+					}
+					file2StackMap[relPath] = append(file2StackMap[relPath], relStackPath)
+					file2ProjMap[relPath] = append(file2ProjMap[relPath], relProjPath)
+					entranceFiles = append(entranceFiles, relPath)
+				}
+				sFiles, err := listFiles(stack.GetPath(), true)
+				if err != nil {
+					return err
+				}
+				for _, file := range sFiles {
+					rel, _ := filepath.Rel(o.workDir, file)
+					if _, ok := file2StackMap[rel]; !ok {
+						file2StackMap[rel] = append(file2StackMap[rel], relStackPath)
+						file2ProjMap[rel] = append(file2ProjMap[rel], relProjPath)
+					}
+				}
+			}
+		}
+		affectedFiles, err := kcl.ListDownStreamFiles(o.workDir, &list.DepOption{
+			Files:        entranceFiles,
+			ChangedPaths: o.Focus,
+		})
+		if err != nil {
+			return err
+		}
+		var fileMap map[string][]string
+		switch o.Only {
+		case "project":
+			fileMap = file2ProjMap
+		case "stack":
+			fileMap = file2StackMap
+		default:
+			return fmt.Errorf("invalid output downstream type. supported types: project, stack")
+		}
+		affected := map[string]bool{}
+		for _, affect := range affectedFiles {
+			// filter
+			if stacks, ok := fileMap[affect]; ok {
+				for _, stack := range stacks {
+					affected[stack] = true
+				}
+			}
+		}
+		for name := range affected {
+			fmt.Println(name)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupport diretion")
+	}
+}
+
+func listFiles(root string, resursive bool) ([]string, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+	files := []string{}
+	for _, file := range entries {
+		if !file.IsDir() {
+			files = append(files, filepath.Join(root, file.Name()))
+		} else if resursive {
+			subFiles, err := listFiles(filepath.Join(root, file.Name()), resursive)
+			if err != nil {
+				return nil, err
+			}
+			files = append(files, subFiles...)
+		}
+	}
+	return files, nil
+}


### PR DESCRIPTION
## Feature Description

this PR solved issue #37 and provide a implementation by parsing the import statement in KCL files

support kusion deps subcommand. By kusion deps, we can list the upstream or the downstream files that have a direct/indirect dependency relationship with the focused files.

## Usage Description & Example
- command usage:
```
Show the KCL file dependency information in the current directory or the given workdir. By default, it will list all the
KCL files that are dependent on the given package path.

Options:
      --direct='up': the inspect direct of the dependency information. Valid values: up, down. Defaults to up
      --focus=[]: the paths to focus on to inspect. It cannot be empty and each path needs to be a valid relative path
from the workdir
      --ignore=[]: the file paths to ignore when filtering the affected stacks/projects. Each path needs to be a valid
relative path from the workdir. If not set, no paths will be ignored.
      --only='project': when direct is set to "down", "only" means only the downstream project/stack list will be output.
Valid values: project, stack. Defaults to project

Usage:
  kusion deps [WORKDIR] [flags] [options]
```

- examples:
```
# List all the KCL files that are dependent by the given focus paths
kusion deps --focus path/to/focus1 --focus path/to/focus2

# List all the projects that depend on the given focus paths
kusion deps --direct down --focus path/to/focus1 --focus path/to/focus2

# List all the stacks that depend on the given focus paths
kusion deps --direct down --focus path/to/focus1 --focus path/to/focus2 --only stack

# List all the projects that depend on the given focus paths, ignoring some paths from entrance files in each stack
kusion deps --direct down --focus path/to/focus1 --focus path/to/focus2 --ignore path/to/ignore
```