### PR TITLE
chore: supplement libssl-dev dependency in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN chmod +x /kusion/bin/kusion \
 
 # Install dependency
 RUN apt-get update -y
-RUN apt-get install -y clang-12 lld-12 --no-install-recommends
+RUN apt-get install -y clang-12 lld-12 libssl-dev --no-install-recommends
 RUN apt-get clean all
 RUN ln -sf /usr/bin/clang-12   /usr/bin/clang
 RUN ln -sf /usr/bin/wasm-ld-12 /usr/bin/wasm-ld


### PR DESCRIPTION
Purpose:
* fix openssl error  
scene: https://github.com/KusionStack/konfig/runs/6500813553?check_suite_focus=true

![image](https://user-images.githubusercontent.com/9360247/169254829-7faaf4a4-90ac-437d-8071-92dc33f411ed.png)
