### PR TITLE
bugfix: runtime apply and detail prompt cancel unexpectly

### DIFF
--- a/pkg/engine/operation/change.go
+++ b/pkg/engine/operation/change.go
@@ -29,7 +29,7 @@ type ChangeStep struct {
 // TODO: 3-way diff
 func (cs *ChangeStep) Diff() (string, error) {
 	// Generate diff report
-	diffReport, err := diffToReport(cs.Original, cs.Modified)
+	diffReport, err := diffToReport(cs.Current, cs.Modified)
 	if err != nil {
 		log.Errorf("failed to compute diff with ChangeStep ID: %s", cs.ID)
 		return "", err

--- a/pkg/engine/operation/preview.go
+++ b/pkg/engine/operation/preview.go
@@ -27,7 +27,7 @@ type PreviewResponse struct {
 	Order *ChangeOrder
 }
 
-func (o *Operation) Preview(request *PreviewRequest, operation Type) (rsp *PreviewResponse, s status.Status) {
+func (o *Operation) Preview(request *PreviewRequest) (rsp *PreviewResponse, s status.Status) {
 	defer func() {
 		if e := recover(); e != nil {
 			log.Error("preview panic:%v", e)
@@ -56,11 +56,11 @@ func (o *Operation) Preview(request *PreviewRequest, operation Type) (rsp *Previ
 	// 1. init & build Indexes
 	priorState, resultState = initStates(o.StateStorage, &request.Request)
 
-	switch operation {
-	case Apply:
+	switch o.OperationType {
+	case ApplyPreview:
 		priorStateResourceIndex = priorState.Resources.Index()
 		graph, s = NewApplyGraph(request.Manifest, priorState)
-	case Destroy:
+	case DestroyPreview:
 		resources := request.Request.Manifest.Resources
 		priorStateResourceIndex = resources.Index()
 		graph, s = NewDestroyGraph(resources)
@@ -74,7 +74,7 @@ func (o *Operation) Preview(request *PreviewRequest, operation Type) (rsp *Previ
 
 	previewOperation := &PreviewOperation{
 		Operation: Operation{
-			OperationType:           Preview,
+			OperationType:           o.OperationType,
 			StateStorage:            o.StateStorage,
 			CtxResourceIndex:        map[string]*models.Resource{},
 			PriorStateResourceIndex: priorStateResourceIndex,

--- a/pkg/engine/operation/types.go
+++ b/pkg/engine/operation/types.go
@@ -6,6 +6,7 @@ type Type int64
 const (
 	UndefinedOperation Type = iota // invalidate value
 	Apply
-	Preview
+	ApplyPreview
 	Destroy
+	DestroyPreview
 )

--- a/pkg/kusionctl/cmd/apply/options.go
+++ b/pkg/kusionctl/cmd/apply/options.go
@@ -106,10 +106,10 @@ func (o *ApplyOptions) Run() error {
 					return err
 				}
 				changes.OutputDiff(target)
+			} else {
+				fmt.Println("Operation apply canceled")
+				return nil
 			}
-
-			fmt.Println("Operation apply canceled")
-			return nil
 		}
 	}
 

--- a/pkg/kusionctl/cmd/apply/options.go
+++ b/pkg/kusionctl/cmd/apply/options.go
@@ -141,9 +141,10 @@ func preview(o *ApplyOptions, planResources *models.Spec,
 
 	pc := &operation.PreviewOperation{
 		Operation: operation.Operation{
-			Runtime:      kubernetesRuntime,
-			StateStorage: &states.FileSystemState{Path: filepath.Join(o.WorkDir, states.KusionState)},
-			Order:        &operation.ChangeOrder{StepKeys: []string{}, ChangeSteps: map[string]*operation.ChangeStep{}},
+			OperationType: operation.ApplyPreview,
+			Runtime:       kubernetesRuntime,
+			StateStorage:  &states.FileSystemState{Path: filepath.Join(o.WorkDir, states.KusionState)},
+			Order:         &operation.ChangeOrder{StepKeys: []string{}, ChangeSteps: map[string]*operation.ChangeStep{}},
 		},
 	}
 
@@ -157,7 +158,7 @@ func preview(o *ApplyOptions, planResources *models.Spec,
 			Stack:    stack.Name,
 			Manifest: planResources,
 		},
-	}, operation.Apply)
+	})
 	if status.IsErr(s) {
 		return nil, fmt.Errorf("preview failed.\n%s", s.String())
 	}

--- a/pkg/kusionctl/cmd/apply/options_test.go
+++ b/pkg/kusionctl/cmd/apply/options_test.go
@@ -151,7 +151,7 @@ func (f *fakerRuntime) Watch(ctx context.Context, resourceState *models.Resource
 
 func mockOperationPreview() {
 	monkey.Patch((*operation.Operation).Preview,
-		func(*operation.Operation, *operation.PreviewRequest, operation.Type) (rsp *operation.PreviewResponse, s status.Status) {
+		func(*operation.Operation, *operation.PreviewRequest) (rsp *operation.PreviewResponse, s status.Status) {
 			return &operation.PreviewResponse{
 				Order: &operation.ChangeOrder{
 					StepKeys: []string{sa1.ID, sa2.ID, sa3.ID},

--- a/pkg/kusionctl/cmd/destroy/options.go
+++ b/pkg/kusionctl/cmd/destroy/options.go
@@ -127,9 +127,10 @@ func (o *DestroyOptions) preview(planResources *models.Spec,
 
 	pc := &operation.PreviewOperation{
 		Operation: operation.Operation{
-			Runtime:      kubernetesRuntime,
-			StateStorage: &states.FileSystemState{Path: filepath.Join(o.WorkDir, states.KusionState)},
-			Order:        &operation.ChangeOrder{StepKeys: []string{}, ChangeSteps: map[string]*operation.ChangeStep{}},
+			OperationType: operation.DestroyPreview,
+			Runtime:       kubernetesRuntime,
+			StateStorage:  &states.FileSystemState{Path: filepath.Join(o.WorkDir, states.KusionState)},
+			Order:         &operation.ChangeOrder{StepKeys: []string{}, ChangeSteps: map[string]*operation.ChangeStep{}},
 		},
 	}
 
@@ -143,7 +144,7 @@ func (o *DestroyOptions) preview(planResources *models.Spec,
 			Stack:    stack.Name,
 			Manifest: planResources,
 		},
-	}, operation.Destroy)
+	})
 	if status.IsErr(s) {
 		return nil, fmt.Errorf("preview failed, status: %v", s)
 	}

--- a/pkg/kusionctl/cmd/destroy/options_test.go
+++ b/pkg/kusionctl/cmd/destroy/options_test.go
@@ -143,7 +143,7 @@ func (f *fakerRuntime) Watch(ctx context.Context, resourceState *models.Resource
 
 func mockOperationPreview() {
 	monkey.Patch((*operation.Operation).Preview,
-		func(*operation.Operation, *operation.PreviewRequest, operation.Type) (rsp *operation.PreviewResponse, s status.Status) {
+		func(*operation.Operation, *operation.PreviewRequest) (rsp *operation.PreviewResponse, s status.Status) {
 			return &operation.PreviewResponse{
 				Order: &operation.ChangeOrder{
 					StepKeys: []string{sa1.ID},


### PR DESCRIPTION
### issue

fix: https://github.com/KusionStack/kusion/issues/65

### action
- runtime apply should differ create or patch, json merge patch cannot applied to an object which is not existed
- prompt cycle has a cancel condition, which is triggered every time
- refactor computing node's action logic
- use live state and plan state to make a diff report which is consistent with runtime logic

