### PR TITLE
fix unit test for pkg/scaffold/internal

### DIFF
--- a/pkg/scaffold/external_templates_test.go
+++ b/pkg/scaffold/external_templates_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"bou.ke/monkey"
+	"github.com/jinzhu/copier"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/gitutil"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -107,15 +108,12 @@ func TestTemplateRepository_Templates(t *testing.T) {
 	})
 
 	t.Run("read from subdir", func(t *testing.T) {
-		originalSubDir := localTemplateRepo.SubDirectory
-		defer func() {
-			localTemplateRepo.SubDirectory = originalSubDir
-		}()
-
-		localTemplateRepo.SubDirectory = localTemplateRepo.Root
-		templates, err := localTemplateRepo.Templates()
+		subRepo := TemplateRepository{}
+		copier.Copy(&subRepo, &localTemplateRepo)
+		subRepo.SubDirectory = localTemplateRepo.Root
+		templates, err := subRepo.Templates()
 		assert.Nil(t, err)
-		assert.Equal(t, []Template{localTemplate}, templates)
+		assert.Contains(t, templates, localTemplate)
 	})
 }
 
@@ -266,8 +264,6 @@ func TestCopyTemplateFiles(t *testing.T) {
 		}
 		stack2Configs[stack.Name] = configs
 	}
-	// project name
-	projectName := localTemplate.ProjectName
-	err = CopyTemplateFiles(localRoot, tmp, true, projectName, projectConfigs, stack2Configs)
+	err = CopyTemplateFiles(localTemplate.Dir, tmp, true, localTemplate.ProjectName, projectConfigs, stack2Configs)
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
### TestTemplateRepository_Templates
UT `read from subdir` means to fetch 2 or more templates from `pkg/scaffold/internal`, now we have only one template, which is not compatible with more templates in the future.

### TestCopyTemplateFiles

The flaw of this one is pretty the same as above. Copy templates from src dir to target dir, now src dir contains only one, so it's not compatible with more templates as well.
