### PR TITLE
feat: refactor CopyTemplateFiles to support different file system

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pterm/pterm v0.12.42-0.20220427210824-6bb8c6e6cc77
 	github.com/sergi/go-diff v1.2.0
+	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -779,6 +779,7 @@ github.com/sourcegraph/jsonrpc2 v0.1.0 h1:ohJHjZ+PcaLxDUjqk2NC3tIGsVa5bXThe1ZheS
 github.com/sourcegraph/jsonrpc2 v0.1.0/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
+github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=

--- a/pkg/kusionctl/cmd/init/options.go
+++ b/pkg/kusionctl/cmd/init/options.go
@@ -33,9 +33,6 @@ func (o *InitOptions) Complete(args []string) error {
 		if len(args) > 0 {
 			// user-specified link
 			o.TemplateNameOrURL = args[0]
-		} else {
-			// official link
-			o.TemplateNameOrURL = scaffold.KusionTemplateGitRepository
 		}
 	} else { // use offline templates, internal templates or user-specified local dir
 		if len(args) > 0 {
@@ -194,7 +191,7 @@ func (o *InitOptions) Run() error {
 	desDir := filepath.Join(cwd, o.ProjectName)
 
 	// Actually copy the files.
-	if err = scaffold.CopyTemplateFiles(template.Dir, desDir, o.Force, &tc); err != nil {
+	if err = scaffold.RenderLocalTemplate(template.Dir, desDir, o.Force, &tc); err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("template '%s' not found: %w", template.Name, err)
 		}

--- a/pkg/scaffold/internal_templates.go
+++ b/pkg/scaffold/internal_templates.go
@@ -5,10 +5,16 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+
+	"github.com/spf13/afero"
 )
 
-//go:embed internal
-var localTemplates embed.FS
+var (
+	//go:embed internal
+	internalTemplates embed.FS
+
+	internalDir = "internal"
+)
 
 // GenInternalTemplates save localTemplates(FS) to internal-templates(target directory)
 func GenInternalTemplates() error {
@@ -16,7 +22,7 @@ func GenInternalTemplates() error {
 	if err != nil {
 		return err
 	}
-	return fs.WalkDir(localTemplates, ".", func(path string, d fs.DirEntry, err error) error {
+	return fs.WalkDir(internalTemplates, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -27,7 +33,7 @@ func GenInternalTemplates() error {
 				return err
 			}
 		} else {
-			bytes, err := localTemplates.ReadFile(path)
+			bytes, err := internalTemplates.ReadFile(path)
 			if err != nil {
 				return err
 			}
@@ -39,4 +45,60 @@ func GenInternalTemplates() error {
 		}
 		return nil
 	})
+}
+
+// Export internal templates which is embed in binary
+func GetInternalTemplates() embed.FS {
+	return internalTemplates
+}
+
+// Transfer embed.FS into afero.Fs
+func Transfer(srcFS embed.FS) (afero.Fs, error) {
+	destFS := afero.NewMemMapFs()
+	return destFS, fs.WalkDir(srcFS, internalDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if err = destFS.MkdirAll(path, DefaultDirectoryPermission); err != nil {
+				return err
+			}
+		} else {
+			// Read source file content
+			content, err := fs.ReadFile(internalTemplates, path)
+			if err != nil {
+				return err
+			}
+			// Create or Update
+			writer, err := destFS.OpenFile(path, CreateOrUpdate, DefaultFilePermission)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if closeErr := writer.Close(); err == nil && closeErr != nil {
+					err = closeErr
+				}
+			}()
+			// Write into FS
+			if _, err := writer.Write(content); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// InternalTemplateNameToPath return a map of template name to path
+func InternalTemplateNameToPath() map[string]string {
+	schemaToPath := make(map[string]string)
+	dirs, err := fs.ReadDir(internalTemplates, internalDir)
+	if err != nil {
+		return schemaToPath
+	}
+	for _, dir := range dirs {
+		if dir.IsDir() {
+			schemaToPath[dir.Name()] = filepath.Join(internalDir, dir.Name())
+		}
+	}
+	return schemaToPath
 }


### PR DESCRIPTION
related: https://github.com/KusionStack/kusion/issues/72#issuecomment-1157618380

Refactor `CopyTemplateFiles()`(rename to `RenderLocalTemplate()`) to support different file system, not only local directory:
1. For the built-in templates, we must use the `go:embed` command, otherwise, we cannot compile it into binary, and we cannot access the built-in templates directory because of a relative path.
2. Render the template to the specified directory, the whole process is divided into 3 steps:
   1. `ReadTemplate()`: read the local path to srcFS
   2. `RenderFSTemplate()`: render srcFS to destFS
   3. `WriteToDisk()`: write to disk
3. For third-party integration scenarios, you can choose one:
   1. Local directory: `RenderLocalTemplate()`
   2. Self-provided memory file system: `RenderFSTemplate()`
   3. Built-in template that comes with the scaffold package: `GetInternalTemplates()`