### PR TITLE
 bugfix: yaml.v2 unmarshal json content, make metadata type map[interface{}]interface{}

### DIFF
--- a/pkg/engine/states/local/filesystem_state.go
+++ b/pkg/engine/states/local/filesystem_state.go
@@ -7,12 +7,10 @@ import (
 	"os"
 	"time"
 
-	"kusionstack.io/kusion/pkg/engine/states"
-
-	"gopkg.in/yaml.v2"
-
 	"github.com/zclconf/go-cty/cty"
+	"gopkg.in/yaml.v3"
 
+	"kusionstack.io/kusion/pkg/engine/states"
 	"kusionstack.io/kusion/pkg/log"
 )
 

--- a/pkg/engine/states/remote/db_state.go
+++ b/pkg/engine/states/remote/db_state.go
@@ -8,22 +8,19 @@ import (
 	"net/url"
 	"sort"
 
-	"kusionstack.io/kusion/pkg/engine/states"
-
-	"kusionstack.io/kusion/pkg/engine/models"
-
+	"github.com/didi/gendry/manager"
 	"github.com/didi/gendry/scanner"
+	_ "github.com/go-sql-driver/mysql"
 	"github.com/jinzhu/copier"
-	"gopkg.in/yaml.v2"
+	"github.com/zclconf/go-cty/cty"
+	"gopkg.in/yaml.v3"
 
 	"kusionstack.io/kusion/pkg/engine/dal/mapper"
+	"kusionstack.io/kusion/pkg/engine/models"
+	"kusionstack.io/kusion/pkg/engine/states"
 	"kusionstack.io/kusion/pkg/log"
 	"kusionstack.io/kusion/pkg/util"
 	jsonutil "kusionstack.io/kusion/pkg/util/json"
-
-	"github.com/didi/gendry/manager"
-	_ "github.com/go-sql-driver/mysql"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func init() {

--- a/pkg/util/yaml/yaml.go
+++ b/pkg/util/yaml/yaml.go
@@ -111,6 +111,7 @@ func MustGetByPath(doc io.Reader, path *yaml.Path) string {
 	return expectNode.String()
 }
 
+// TODO: yamlv3.Marshal will reduce leading "/n" character
 // Merge multiple yaml documents into a single string,
 // separate yaml documents with '---'
 func MergeToOneYAML(yamlList ...interface{}) string {


### PR DESCRIPTION
- use ` gopkg.in/yaml.v3` instead of ` gopkg.in/yaml.v2`, and change the db_stage by the way
- runtime dry-run not cover `create` verb, add it
