### PR TITLE
bugfix: stack directory name is map key of Template.StacksConfig

### DIFF
--- a/pkg/scaffold/templates.go
+++ b/pkg/scaffold/templates.go
@@ -460,7 +460,7 @@ func RenderFSTemplate(srcFS afero.Fs, srcDir string, destFS afero.Fs, destDir st
 					configs[k] = v
 				}
 				// Skip if stackConfigs are not provided
-				stackConfigs, exits := tc.StacksConfig[fileInfo.Name()]
+				stackConfigs, exits := tc.StacksConfig[d.Name()]
 				if !exits {
 					continue
 				}


### PR DESCRIPTION
wrong use `stack.yaml` as map key of Template.StackConfigs, stack directory name is correct.