### PR TITLE
feat: support k8s crd in kusion apply and kusion destroy

### DIFF
--- a/pkg/compile/compile_test.go
+++ b/pkg/compile/compile_test.go
@@ -214,3 +214,34 @@ func mockRunFiles(mockErr error) {
 // 		return &CompileResult{}, nil
 // 	})
 // }
+
+func Test_appendCRDs(t *testing.T) {
+	t.Run("append one CRD", func(t *testing.T) {
+		cs := &CompileResult{}
+		err := appendCRDs("./testdata/crd", cs)
+		assert.Nil(t, err)
+		assert.NotNil(t, cs.Documents)
+		assert.NotEmpty(t, cs.RawYAMLResult)
+	})
+
+	t.Run("no CRD to append", func(t *testing.T) {
+		cs := &CompileResult{}
+		err := appendCRDs("./testdata", cs)
+		assert.Nil(t, err)
+		assert.Nil(t, cs.Documents)
+		assert.Empty(t, cs.RawYAMLResult)
+	})
+}
+
+func Test_readCRDsIfExists(t *testing.T) {
+	t.Run("read CRDs", func(t *testing.T) {
+		crds, err := readCRDs("./testdata/crd")
+		assert.Nil(t, err)
+		assert.NotNil(t, crds)
+	})
+	t.Run("no CRDs", func(t *testing.T) {
+		crds, err := readCRDs("./testdata")
+		assert.Nil(t, err)
+		assert.Nil(t, crds)
+	})
+}

--- a/pkg/compile/testdata/crd/foo.yaml
+++ b/pkg/compile/testdata/crd/foo.yaml
@@ -1,0 +1,37 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.samplecontroller.k8s.io
+  # for more information on the below annotation, please see
+  # https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/2337-k8s.io-group-protection/README.md
+  annotations:
+    "api-approved.kubernetes.io": "unapproved, experimental-only; please get an approval from Kubernetes API reviewers if you're trying to develop a CRD in the *.k8s.io or *.kubernetes.io groups"
+spec:
+  group: samplecontroller.k8s.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        # schema used for validation
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                deploymentName:
+                  type: string
+                replicas:
+                  type: integer
+                  minimum: 1
+                  maximum: 10
+            status:
+              type: object
+              properties:
+                availableReplicas:
+                  type: integer
+  names:
+    kind: Foo
+    plural: foos
+  scope: Namespaced

--- a/pkg/resources/crd/crd.go
+++ b/pkg/resources/crd/crd.go
@@ -1,0 +1,76 @@
+package crd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	"kusionstack.io/kusion/pkg/resources"
+)
+
+const (
+	Directory = "crd"
+)
+
+var FileExtensions = []string{".yaml", ".yml", ".json"}
+
+type crdVisitor struct {
+	Path string
+}
+
+func NewVisitor(path string) resources.Visitor {
+	return &crdVisitor{Path: path}
+}
+
+// Visit read all YAML files under target path
+func (v *crdVisitor) Visit() (objs []interface{}, err error) {
+	err = filepath.WalkDir(v.Path, func(filePath string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// check file extension
+		if ignoreFile(filePath, FileExtensions) {
+			return nil
+		}
+
+		f, err := os.Open(filePath)
+		if err != nil {
+			return err
+		}
+		decoder := yaml.NewYAMLOrJSONDecoder(f, 4096)
+		for {
+			data := make(map[string]interface{})
+			if err := decoder.Decode(&data); err != nil {
+				if err == io.EOF {
+					return nil
+				}
+				return fmt.Errorf("error parsing %s: %v", filePath, err)
+			}
+			if len(data) == 0 {
+				continue
+			}
+
+			objs = append(objs, data)
+		}
+	})
+	return objs, err
+}
+
+// ignoreFile indicates a filename is ended with specified extension or not
+func ignoreFile(path string, extensions []string) bool {
+	if len(extensions) == 0 {
+		return false
+	}
+	ext := filepath.Ext(path)
+	for _, s := range extensions {
+		if strings.EqualFold(s, ext) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/resources/crd/crd_test.go
+++ b/pkg/resources/crd/crd_test.go
@@ -1,0 +1,49 @@
+package crd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCrdVisitor(t *testing.T) {
+	t.Run("read single file", func(t *testing.T) {
+		visitor := crdVisitor{
+			Path: "./testdata/one.yaml",
+		}
+		objs, err := visitor.Visit()
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(objs))
+	})
+
+	t.Run("read multi files", func(t *testing.T) {
+		visitor := crdVisitor{
+			Path: "./testdata",
+		}
+		objs, err := visitor.Visit()
+		assert.Nil(t, err)
+		assert.Equal(t, 3, len(objs))
+	})
+}
+
+func Test_ignoreFile(t *testing.T) {
+	t.Run("not ignore .YAML file", func(t *testing.T) {
+		flag := ignoreFile("foo.YAML", FileExtensions)
+		assert.False(t, flag)
+	})
+
+	t.Run("not ignore .yaml file", func(t *testing.T) {
+		flag := ignoreFile("foo.yaml", FileExtensions)
+		assert.False(t, flag)
+	})
+
+	t.Run("not ignore .yml file", func(t *testing.T) {
+		flag := ignoreFile("foo.yml", FileExtensions)
+		assert.False(t, flag)
+	})
+
+	t.Run("ignore .go file", func(t *testing.T) {
+		flag := ignoreFile("bar.go", FileExtensions)
+		assert.True(t, flag)
+	})
+}

--- a/pkg/resources/crd/testdata/multi.yaml
+++ b/pkg/resources/crd/testdata/multi.yaml
@@ -1,0 +1,66 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.samplecontroller.k8s.io
+  # for more information on the below annotation, please see
+  # https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/2337-k8s.io-group-protection/README.md
+  annotations:
+    "api-approved.kubernetes.io": "unapproved, experimental-only; please get an approval from Kubernetes API reviewers if you're trying to develop a CRD in the *.k8s.io or *.kubernetes.io groups"
+spec:
+  group: samplecontroller.k8s.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        # schema used for validation
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                deploymentName:
+                  type: string
+                replicas:
+                  type: integer
+                  minimum: 1
+                  maximum: 10
+            status:
+              type: object
+              properties:
+                availableReplicas:
+                  type: integer
+  names:
+    kind: Foo
+    plural: foos
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: guestbooks.apps.ibm.com
+spec:
+  group: apps.ibm.com
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                guestbookTitle:
+                  type: string
+                guestbookSubtitle:
+                  type: string
+  scope: Namespaced
+  names:
+    plural: guestbooks
+    singular: guestbook
+    kind: Guestbook
+    shortNames:
+      - gb

--- a/pkg/resources/crd/testdata/one.yaml
+++ b/pkg/resources/crd/testdata/one.yaml
@@ -1,0 +1,37 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foos.samplecontroller.k8s.io
+  # for more information on the below annotation, please see
+  # https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/2337-k8s.io-group-protection/README.md
+  annotations:
+    "api-approved.kubernetes.io": "unapproved, experimental-only; please get an approval from Kubernetes API reviewers if you're trying to develop a CRD in the *.k8s.io or *.kubernetes.io groups"
+spec:
+  group: samplecontroller.k8s.io
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        # schema used for validation
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                deploymentName:
+                  type: string
+                replicas:
+                  type: integer
+                  minimum: 1
+                  maximum: 10
+            status:
+              type: object
+              properties:
+                availableReplicas:
+                  type: integer
+  names:
+    kind: Foo
+    plural: foos
+  scope: Namespaced

--- a/pkg/resources/visitor.go
+++ b/pkg/resources/visitor.go
@@ -1,0 +1,6 @@
+package resources
+
+// Visitor walks a list of resources under target path.
+type Visitor interface {
+	Visit() ([]interface{}, error)
+}


### PR DESCRIPTION
fix issue: https://github.com/KusionStack/kusion/issues/66

Support k8s CRD in `kusion apply` and `kusion destroy`:

**Precondition:** 
- CRD files are in YAML or JSON format, stored in `crd` directory under project path

**Operations:**
- Read all CRD files (`readCRDs()`) and append to compiled result (`appendCRDs()`)