### PR TITLE
bugfix: save unchanged but lived resource

### DIFF
--- a/pkg/engine/operation/graph/resource_node.go
+++ b/pkg/engine/operation/graph/resource_node.go
@@ -97,16 +97,8 @@ func (rn *ResourceNode) Execute(operation *opsmodels.Operation) status.Status {
 	case types.ApplyPreview, types.DestroyPreview:
 		fillResponseChangeSteps(operation, rn, liveState, predictableState)
 	case types.Apply, types.Destroy:
-		switch rn.Action {
-		case types.Create, types.Delete, types.Update:
-			s := rn.applyResource(operation, priorState, planedState)
-			if status.IsErr(s) {
-				return s
-			}
-		case types.UnChange:
-			log.Infof("PriorAttributes and PlanAttributes are equal.")
-		default:
-			return status.NewErrorStatus(fmt.Errorf("unknown action:%s", rn.Action.PrettyString()))
+		if s = rn.applyResource(operation, priorState, planedState); status.IsErr(s) {
+			return s
 		}
 	default:
 		return status.NewErrorStatus(fmt.Errorf("unknown operation: %v", operation.OperationType))
@@ -137,6 +129,9 @@ func (rn *ResourceNode) applyResource(operation *opsmodels.Operation, priorState
 		if s != nil {
 			log.Debugf("delete state: %v", s.String())
 		}
+	case types.UnChange:
+		log.Infof("planed resource not update live state")
+		res = planedState
 	}
 	if status.IsErr(s) {
 		return s

--- a/pkg/engine/operation/models/operation_context.go
+++ b/pkg/engine/operation/models/operation_context.go
@@ -84,7 +84,7 @@ func (o *Operation) RefreshResourceIndex(resourceKey string, resource *models.Re
 	case types.Delete:
 		o.CtxResourceIndex[resourceKey] = nil
 		o.StateResourceIndex[resourceKey] = nil
-	case types.Create, types.Update:
+	case types.Create, types.Update, types.UnChange:
 		o.CtxResourceIndex[resourceKey] = resource
 		o.StateResourceIndex[resourceKey] = resource
 	default:


### PR DESCRIPTION
fix: https://github.com/KusionStack/kusion/issues/102

`Resource` is living in `Runtime`, but not applied by kusion, next time user use kusion to apply the same `Resource` but no changes, kusion should save it in `State`
