### PR TITLE
bugfix: resource nodes of delete action don't need compute action type again

### DIFF
--- a/pkg/engine/operation/graph/resource_node_test.go
+++ b/pkg/engine/operation/graph/resource_node_test.go
@@ -177,7 +177,7 @@ func TestResourceNode_Execute(t *testing.T) {
 				})
 			monkey.PatchInstanceMethod(reflect.TypeOf(tt.args.operation.Runtime), "Delete",
 				func(k *runtime.KubernetesRuntime, ctx context.Context, request *runtime.DeleteRequest) *runtime.DeleteResponse {
-					return nil
+					return &runtime.DeleteResponse{Status: nil}
 				})
 			monkey.PatchInstanceMethod(reflect.TypeOf(tt.args.operation.Runtime), "Read",
 				func(k *runtime.KubernetesRuntime, ctx context.Context, request *runtime.ReadRequest) *runtime.ReadResponse {

--- a/pkg/engine/operation/preview_test.go
+++ b/pkg/engine/operation/preview_test.go
@@ -164,7 +164,7 @@ func TestOperation_Preview(t *testing.T) {
 							ID:     "fake-id-2",
 							Action: types.Delete,
 							From:   &FakeResourceState2,
-							To:     &FakeResourceState2,
+							To:     (*models.Resource)(nil),
 						},
 					},
 				},


### PR DESCRIPTION
fix: https://github.com/KusionStack/kusion/issues/109

**Root Causes**

- `kusion apply` will build an acyclic graph which contains  only two kinds of action, `Update` and `Delete`, only `Update` nodes need to determine `Create` or `Update`
- Nodes of `Update` action, its state field is **plan state**; otherwise, node of `Delete` action, its state field is **prior state**
- For nodes of `Delete` action, wrongly used `node.state` as plan state in `execute()` func, so `Delete` turns to `Unchange`