### PR TITLE
bugfix: invalid argument for "-D, --argument" flag: parse error, bare " in non-quoted-field

### DIFF
--- a/pkg/kusionctl/cmd/apply/apply.go
+++ b/pkg/kusionctl/cmd/apply/apply.go
@@ -50,16 +50,9 @@ func NewCmdApply() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&o.CompileOptions.WorkDir, "workdir", "w", "",
-		i18n.T("Specify the work directory"))
+	o.AddCompileFlags(cmd)
 	cmd.Flags().StringVarP(&o.Operator, "operator", "", "",
 		i18n.T("Specify the operator"))
-	cmd.Flags().StringSliceVarP(&o.CompileOptions.Arguments, "argument", "D", []string{},
-		i18n.T("Specify the arguments to apply KCL"))
-	cmd.Flags().StringSliceVarP(&o.CompileOptions.Settings, "setting", "Y", []string{},
-		i18n.T("Specify the command line setting files"))
-	cmd.Flags().StringSliceVarP(&o.CompileOptions.Overrides, "overrides", "O", []string{},
-		i18n.T("Specify the configuration override path and value"))
 	cmd.Flags().BoolVarP(&o.Yes, "yes", "y", false,
 		i18n.T("Automatically approve and perform the update after previewing it"))
 	cmd.Flags().BoolVarP(&o.Detail, "detail", "d", false,

--- a/pkg/kusionctl/cmd/compile/compile.go
+++ b/pkg/kusionctl/cmd/compile/compile.go
@@ -56,20 +56,24 @@ func NewCmdCompile() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringSliceVarP(&o.Arguments, "argument", "D", []string{},
-		i18n.T("Specify the top-level argument"))
-	cmd.Flags().StringSliceVarP(&o.Settings, "setting", "Y", []string{},
-		i18n.T("Specify the command line setting files"))
+	o.AddCompileFlags(cmd)
 	cmd.Flags().StringVarP(&o.Output, "output", "o", "",
 		i18n.T("Specify the output file"))
-	cmd.Flags().StringVarP(&o.WorkDir, "workdir", "w", "",
-		i18n.T("Specify the work directory"))
 	cmd.Flags().BoolVarP(&o.DisableNone, "disable-none", "n", false,
 		i18n.T("Disable dumping None values"))
 	cmd.Flags().BoolVarP(&o.OverrideAST, "override-AST", "a", false,
 		i18n.T("Specify the override option"))
-	cmd.Flags().StringSliceVarP(&o.Overrides, "overrides", "O", []string{},
-		i18n.T("Specify the configuration override path and value"))
 
 	return cmd
+}
+
+func (o *CompileOptions) AddCompileFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.WorkDir, "workdir", "w", "",
+		i18n.T("Specify the work directory"))
+	cmd.Flags().StringSliceVarP(&o.Settings, "setting", "Y", []string{},
+		i18n.T("Specify the command line setting files"))
+	cmd.Flags().StringArrayVarP(&o.Arguments, "argument", "D", []string{},
+		i18n.T("Specify the top-level argument"))
+	cmd.Flags().StringSliceVarP(&o.Overrides, "overrides", "O", []string{},
+		i18n.T("Specify the configuration override path and value"))
 }

--- a/pkg/kusionctl/cmd/destroy/destroy.go
+++ b/pkg/kusionctl/cmd/destroy/destroy.go
@@ -43,16 +43,9 @@ func NewCmdDestroy() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&o.CompileOptions.WorkDir, "workdir", "w", "",
-		i18n.T("Specify the work directory"))
+	o.AddCompileFlags(cmd)
 	cmd.Flags().StringVarP(&o.Operator, "operator", "", "",
 		i18n.T("Specify the operator"))
-	cmd.Flags().StringSliceVarP(&o.CompileOptions.Arguments, "argument", "D", []string{},
-		i18n.T("Specify the arguments for compile KCL"))
-	cmd.Flags().StringSliceVarP(&o.CompileOptions.Settings, "setting", "Y", []string{},
-		i18n.T("Specify the command line setting files"))
-	cmd.Flags().StringSliceVarP(&o.CompileOptions.Overrides, "overrides", "O", []string{},
-		i18n.T("Specify the configuration override path and value"))
 	cmd.Flags().BoolVarP(&o.Yes, "yes", "y", false,
 		i18n.T("Automatically approve and perform the update after previewing it"))
 	cmd.Flags().BoolVarP(&o.Detail, "detail", "d", false,


### PR DESCRIPTION
fix: #110 

kusion compile flag,  `-D` use `pflag.StringSliceVarP()` to parse string slice arguments, according to the comments here:
https://github.com/spf13/pflag/blob/d5e0c0615acee7028e1e2740a11102313be88de1/string_slice.go#L99
```
compared to StringArray flags, StringSlice flags take comma-separated value as arguments and split them accordingly.
```
so, use `pflag.StringArrayVarP()` instead, will prevent pflag from truncating long string by comma.

After replace, the compiled result meets expectation:
```bash
./kusion compile a.k -D a='["x","y","z"]' -D b='{"key": False}'
```

output:
```yaml
a:
- x
- y
- z
b:
  key: false
```