### PR TITLE
chore: fix version format to match semantic versioning 2.0.0

### DIFF
--- a/pkg/version/types.go
+++ b/pkg/version/types.go
@@ -154,7 +154,7 @@ func NewInfo() (*Info, error) {
 	if isHeadAtTag {
 		releaseVersion = gitVersion.Original()
 	} else {
-		releaseVersion = fmt.Sprintf("%s-%s", gitVersion.Original(), headHashShort)
+		releaseVersion = fmt.Sprintf("%s+%s", gitVersion.Original(), headHashShort)
 	}
 
 	// Get dependency version

--- a/pkg/version/types_test.go
+++ b/pkg/version/types_test.go
@@ -17,6 +17,7 @@ import (
 
 	goversion "github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
+
 	git "kusionstack.io/kusion/pkg/util/gitutil"
 )
 
@@ -147,7 +148,7 @@ func TestKusionVersionNotHeadTag(t *testing.T) {
 	})
 
 	versionJSON := `{
-	"releaseVersion": "v0.3.11-alpha-af79cd23",
+	"releaseVersion": "v0.3.11-alpha+af79cd23",
 	"gitInfo": {
 		"latestTag": "v0.3.11-alpha",
 		"commit": "af79cd231e7ed1dbb00e860da9615febf5f17bf0",


### PR DESCRIPTION
ref: https://semver.org/

```python
from packaging import version

print(version.parse("v0.3.22-2abnsx"))  # Invalid version: v0.3.22-2abnsx 
print(version.parse("v0.3.22.2abnsx"))  # Invalid version: v0.3.22.2abnsx
print(version.parse("v0.3.22+2abnsx")) # Valid version: 0.3.22+2abnsx

print(version.parse("v0.3.22-alpha.01-2abnsx")) # Invalid version: v0.3.22-alpha.01-2abnsx
print(version.parse("v0.3.22-alpha.01.2abnsx")) # Invalid version: v0.3.22-alpha.01.2abnsx
print(version.parse("v0.3.22-alpha.01+2abnsx")) # Valid version: 0.3.22a1+2abnsx 

print(version.parse("v0.3.22-beta.02-2abnsx")) # Invalid version: v0.3.22-beta.02-2abnsx
print(version.parse("v0.3.22-beta.02.2abnsx")) # Invalid version: v0.3.22-beta.02.2abnsx
print(version.parse("v0.3.22-beta.02+2abnsx")) # Valid version: 0.3.22b2+2abnsx

print(version.parse("v0.3.22-rc.0-2abnsx")) # Invalid version: v0.3.22-rc.0-2abnsx
print(version.parse("v0.3.22-rc.0.2abnsx")) # Invalid version: v0.3.22-rc.0.2abnsx
print(version.parse("v0.3.22-rc.0+2abnsx")) # Valid version: 0.3.22rc0+2abnsx
```