### PR TITLE
feat: cmd preview and apply support new flag '--ignore-fields'

### DIFF
--- a/pkg/engine/models/spec.go
+++ b/pkg/engine/models/spec.go
@@ -4,3 +4,14 @@ package models
 type Spec struct {
 	Resources Resources `json:"resources" yaml:"resources"`
 }
+
+// ParseCluster try to parse Cluster from resource extensions.
+// All resources in one compile MUST have the same Cluster and this constraint will be guaranteed by KCL compile logic
+func (s *Spec) ParseCluster() string {
+	resources := s.Resources
+	var cluster string
+	if len(resources) != 0 && resources[0].Extensions != nil && resources[0].Extensions["Cluster"] != nil {
+		cluster = resources[0].Extensions["Cluster"].(string)
+	}
+	return cluster
+}

--- a/pkg/engine/operation/graph/resource_node_test.go
+++ b/pkg/engine/operation/graph/resource_node_test.go
@@ -112,6 +112,7 @@ func TestResourceNode_Execute(t *testing.T) {
 				CtxResourceIndex:        priorStateResourceIndex,
 				PriorStateResourceIndex: priorStateResourceIndex,
 				StateResourceIndex:      priorStateResourceIndex,
+				IgnoreFields:            []string{"not_exist_field"},
 				MsgCh:                   make(chan opsmodels.Message),
 				ResultState:             states.NewState(),
 				Lock:                    &sync.Mutex{},

--- a/pkg/engine/operation/models/change.go
+++ b/pkg/engine/operation/models/change.go
@@ -148,6 +148,16 @@ func (o *ChangeOrder) Diffs() string {
 	return buf.String()
 }
 
+func (p *Changes) AllUnChange() bool {
+	for _, v := range p.ChangeSteps {
+		if v.Action != types.UnChange {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (p *Changes) Summary() {
 	// Create a fork of the default table, fill it with data and print it.
 	// Data can also be generated and inserted later.

--- a/pkg/engine/operation/models/change.go
+++ b/pkg/engine/operation/models/change.go
@@ -3,6 +3,7 @@ package models
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -158,7 +159,7 @@ func (p *Changes) AllUnChange() bool {
 	return true
 }
 
-func (p *Changes) Summary() {
+func (p *Changes) Summary(writer io.Writer) {
 	// Create a fork of the default table, fill it with data and print it.
 	// Data can also be generated and inserted later.
 	tableHeader := []string{fmt.Sprintf("Stack: %s", p.stack.Name), "ID", "Action"}
@@ -179,6 +180,7 @@ func (p *Changes) Summary() {
 		WithLeftAlignment(true).
 		WithSeparator("  ").
 		WithData(tableData).
+		WithWriter(writer).
 		Render()
 	pterm.Println() // Blank line
 }

--- a/pkg/engine/operation/models/change_test.go
+++ b/pkg/engine/operation/models/change_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -432,7 +433,7 @@ func TestChanges_Preview(t *testing.T) {
 				project:     tt.fields.project,
 				stack:       tt.fields.stack,
 			}
-			p.Summary()
+			p.Summary(os.Stdout)
 		})
 	}
 }

--- a/pkg/engine/operation/models/change_test.go
+++ b/pkg/engine/operation/models/change_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"kusionstack.io/kusion/pkg/engine/models"
 	"kusionstack.io/kusion/pkg/engine/operation/types"
 	"kusionstack.io/kusion/pkg/projectstack"
@@ -462,4 +464,34 @@ func Test_buildResourceStateMap(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestChanges_AllUnChange(t *testing.T) {
+	t.Run("changed", func(t *testing.T) {
+		changes := &Changes{
+			ChangeOrder: &ChangeOrder{
+				ChangeSteps: map[string]*ChangeStep{
+					"foo": {
+						Action: types.Update,
+					},
+				},
+			},
+		}
+		flag := changes.AllUnChange()
+		assert.False(t, flag)
+	})
+
+	t.Run("unchanged", func(t *testing.T) {
+		changes := &Changes{
+			ChangeOrder: &ChangeOrder{
+				ChangeSteps: map[string]*ChangeStep{
+					"bar": {
+						Action: types.UnChange,
+					},
+				},
+			},
+		}
+		flag := changes.AllUnChange()
+		assert.True(t, flag)
+	})
 }

--- a/pkg/engine/operation/models/operation_context.go
+++ b/pkg/engine/operation/models/operation_context.go
@@ -34,6 +34,9 @@ type Operation struct {
 	// StateResourceIndex represents resources that will be saved in states.StateStorage
 	StateResourceIndex map[string]*models.Resource
 
+	// IgnoreFields will be ignored in preview stage
+	IgnoreFields []string
+
 	// ChangeOrder is resources' change order during this operation
 	ChangeOrder *ChangeOrder
 

--- a/pkg/engine/operation/preview.go
+++ b/pkg/engine/operation/preview.go
@@ -88,6 +88,7 @@ func (po *PreviewOperation) Preview(request *PreviewRequest) (rsp *PreviewRespon
 			CtxResourceIndex:        map[string]*models.Resource{},
 			PriorStateResourceIndex: priorStateResourceIndex,
 			StateResourceIndex:      priorStateResourceIndex,
+			IgnoreFields:            o.IgnoreFields,
 			ChangeOrder:             o.ChangeOrder,
 			Runtime:                 o.Runtime, // preview need get the latest spec from runtime
 			ResultState:             resultState,

--- a/pkg/kusionctl/cmd/apply/apply.go
+++ b/pkg/kusionctl/cmd/apply/apply.go
@@ -51,19 +51,15 @@ func NewCmdApply() *cobra.Command {
 	}
 
 	o.AddCompileFlags(cmd)
-	cmd.Flags().StringVarP(&o.Operator, "operator", "", "",
-		i18n.T("Specify the operator"))
+	o.AddPreviewFlags(cmd)
+	o.AddBackendFlags(cmd)
+
 	cmd.Flags().BoolVarP(&o.Yes, "yes", "y", false,
 		i18n.T("Automatically approve and perform the update after previewing it"))
-	cmd.Flags().BoolVarP(&o.Detail, "detail", "d", false,
-		i18n.T("Automatically show plan details after previewing it"))
 	cmd.Flags().BoolVarP(&o.NoStyle, "no-style", "", false,
 		i18n.T("no-style sets to RawOutput mode and disables all of styling"))
 	cmd.Flags().BoolVarP(&o.DryRun, "dry-run", "", false,
 		i18n.T("dry-run to preview the execution effect (always successful) without actually applying the changes"))
-	cmd.Flags().StringSliceVarP(&o.IgnoreFields, "ignore-fields", "", nil,
-		i18n.T("Ignore differences of target fields"))
-	o.AddBackendFlags(cmd)
 
 	return cmd
 }

--- a/pkg/kusionctl/cmd/apply/apply.go
+++ b/pkg/kusionctl/cmd/apply/apply.go
@@ -61,6 +61,8 @@ func NewCmdApply() *cobra.Command {
 		i18n.T("no-style sets to RawOutput mode and disables all of styling"))
 	cmd.Flags().BoolVarP(&o.DryRun, "dry-run", "", false,
 		i18n.T("dry-run to preview the execution effect (always successful) without actually applying the changes"))
+	cmd.Flags().StringSliceVarP(&o.IgnoreFields, "ignore-fields", "", nil,
+		i18n.T("Ignore differences of target fields"))
 	o.AddBackendFlags(cmd)
 
 	return cmd

--- a/pkg/kusionctl/cmd/apply/options.go
+++ b/pkg/kusionctl/cmd/apply/options.go
@@ -42,12 +42,7 @@ type ApplyOptions struct {
 // NewApplyOptions returns a new ApplyOptions instance
 func NewApplyOptions() *ApplyOptions {
 	return &ApplyOptions{
-		CompileOptions: compilecmd.CompileOptions{
-			Filenames: []string{},
-			Arguments: []string{},
-			Settings:  []string{},
-			Overrides: []string{},
-		},
+		CompileOptions: *compilecmd.NewCompileOptions(),
 	}
 }
 

--- a/pkg/kusionctl/cmd/apply/options.go
+++ b/pkg/kusionctl/cmd/apply/options.go
@@ -36,6 +36,7 @@ type ApplyOptions struct {
 	DryRun      bool
 	OnlyPreview bool
 	backend.BackendOps
+	IgnoreFields []string
 }
 
 // NewApplyOptions returns a new ApplyOptions instance
@@ -189,6 +190,7 @@ func Preview(
 			OperationType: types.ApplyPreview,
 			Runtime:       runtime,
 			StateStorage:  storage,
+			IgnoreFields:  o.IgnoreFields,
 			ChangeOrder:   &opsmodels.ChangeOrder{StepKeys: []string{}, ChangeSteps: map[string]*opsmodels.ChangeStep{}},
 		},
 	}

--- a/pkg/kusionctl/cmd/apply/options.go
+++ b/pkg/kusionctl/cmd/apply/options.go
@@ -89,7 +89,7 @@ func (o *ApplyOptions) Run() error {
 		return err
 	}
 
-	changes, err := previewcmd.Preview(&o.PreviewOptions, r, stateStorage, planResources, project, stack, os.Stdout)
+	changes, err := previewcmd.Preview(&o.PreviewOptions, r, stateStorage, planResources, project, stack)
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func (o *ApplyOptions) Run() error {
 	}
 
 	// Summary preview table
-	changes.Summary()
+	changes.Summary(os.Stdout)
 
 	// Detail detection
 	if o.Detail && !o.Yes {

--- a/pkg/kusionctl/cmd/apply/options.go
+++ b/pkg/kusionctl/cmd/apply/options.go
@@ -20,7 +20,7 @@ import (
 	"kusionstack.io/kusion/pkg/engine/runtime"
 	runtimeInit "kusionstack.io/kusion/pkg/engine/runtime/init"
 	"kusionstack.io/kusion/pkg/engine/states"
-	compilecmd "kusionstack.io/kusion/pkg/kusionctl/cmd/compile"
+	previewcmd "kusionstack.io/kusion/pkg/kusionctl/cmd/preview"
 	"kusionstack.io/kusion/pkg/log"
 	"kusionstack.io/kusion/pkg/projectstack"
 	"kusionstack.io/kusion/pkg/status"
@@ -28,21 +28,21 @@ import (
 
 // ApplyOptions defines flags for the `apply` command
 type ApplyOptions struct {
-	compilecmd.CompileOptions
-	Operator    string
+	previewcmd.PreviewOptions
+	ApplyFlag
+}
+
+type ApplyFlag struct {
 	Yes         bool
-	Detail      bool
 	NoStyle     bool
 	DryRun      bool
 	OnlyPreview bool
-	backend.BackendOps
-	IgnoreFields []string
 }
 
 // NewApplyOptions returns a new ApplyOptions instance
 func NewApplyOptions() *ApplyOptions {
 	return &ApplyOptions{
-		CompileOptions: *compilecmd.NewCompileOptions(),
+		PreviewOptions: *previewcmd.NewPreviewOptions(),
 	}
 }
 
@@ -76,7 +76,7 @@ func (o *ApplyOptions) Run() error {
 	sp.Success() // Resolve spinner with success message.
 	pterm.Println()
 
-	// Get stateStroage from backend config to manage state
+	// Get state storage from backend config to manage state
 	stateStorage, err := backend.BackendFromConfig(project.Backend, o.BackendOps, o.WorkDir)
 	if err != nil {
 		return err
@@ -84,12 +84,12 @@ func (o *ApplyOptions) Run() error {
 
 	// Compute changes for preview
 	runtimes := runtimeInit.InitRuntime()
-	runtime, err := runtimes[planResources.Resources[0].Type]()
+	r, err := runtimes[planResources.Resources[0].Type]()
 	if err != nil {
 		return err
 	}
 
-	changes, err := Preview(o, runtime, stateStorage, planResources, project, stack, os.Stdout)
+	changes, err := previewcmd.Preview(&o.PreviewOptions, r, stateStorage, planResources, project, stack, os.Stdout)
 	if err != nil {
 		return err
 	}
@@ -132,7 +132,7 @@ func (o *ApplyOptions) Run() error {
 
 	if !o.OnlyPreview {
 		fmt.Println("Start applying diffs ...")
-		if err := Apply(o, runtime, stateStorage, planResources, changes, os.Stdout); err != nil {
+		if err := Apply(o, r, stateStorage, planResources, changes, os.Stdout); err != nil {
 			return err
 		}
 
@@ -143,82 +143,6 @@ func (o *ApplyOptions) Run() error {
 	}
 
 	return nil
-}
-
-// The Preview function calculates the upcoming actions of each resource
-// through the execution Kusion Engine, and you can customize the
-// runtime of engine and the state storage through `runtime` and
-// `storage` parameters.
-//
-// Example:
-//
-//	o := NewApplyOptions()
-//	stateStorage := &states.FileSystemState{
-//	    Path: filepath.Join(o.WorkDir, states.KusionState)
-//	}
-//	kubernetesRuntime, err := runtime.NewKubernetesRuntime()
-//	if err != nil {
-//	    return err
-//	}
-//
-//	changes, err := Preview(o, kubernetesRuntime, stateStorage,
-//	    planResources, project, stack, os.Stdout)
-//	if err != nil {
-//	    return err
-//	}
-//
-// todo @elliotxx io.Writer is not used now
-func Preview(
-	o *ApplyOptions,
-	runtime runtime.Runtime,
-	storage states.StateStorage,
-	planResources *models.Spec,
-	project *projectstack.Project,
-	stack *projectstack.Stack,
-	out io.Writer,
-) (*opsmodels.Changes, error) {
-	log.Info("Start compute preview changes ...")
-
-	// Construct the preview operation
-	pc := &operation.PreviewOperation{
-		Operation: opsmodels.Operation{
-			OperationType: types.ApplyPreview,
-			Runtime:       runtime,
-			StateStorage:  storage,
-			IgnoreFields:  o.IgnoreFields,
-			ChangeOrder:   &opsmodels.ChangeOrder{StepKeys: []string{}, ChangeSteps: map[string]*opsmodels.ChangeStep{}},
-		},
-	}
-
-	log.Info("Start call pc.Preview() ...")
-
-	cluster := parseCluster(planResources)
-	rsp, s := pc.Preview(&operation.PreviewRequest{
-		Request: opsmodels.Request{
-			Tenant:   project.Tenant,
-			Project:  project.Name,
-			Stack:    stack.Name,
-			Operator: o.Operator,
-			Spec:     planResources,
-			Cluster:  cluster,
-		},
-	})
-	if status.IsErr(s) {
-		return nil, fmt.Errorf("preview failed.\n%s", s.String())
-	}
-
-	return opsmodels.NewChanges(project, stack, rsp.Order), nil
-}
-
-// parseCluster try to parse Cluster from resource extensions.
-// All resources in one compile MUST have the same Cluster and this constraint will be guaranteed by KCL compile logic
-func parseCluster(planResources *models.Spec) string {
-	resources := planResources.Resources
-	var cluster string
-	if len(resources) != 0 && resources[0].Extensions != nil && resources[0].Extensions["Cluster"] != nil {
-		cluster = resources[0].Extensions["Cluster"].(string)
-	}
-	return cluster
 }
 
 // The Apply function will apply the resources changes
@@ -341,7 +265,7 @@ func Apply(
 		}
 		close(ac.MsgCh)
 	} else {
-		cluster := parseCluster(planResources)
+		cluster := planResources.ParseCluster()
 		_, st := ac.Apply(&operation.ApplyRequest{
 			Request: opsmodels.Request{
 				Tenant:   changes.Project().Tenant,

--- a/pkg/kusionctl/cmd/apply/options_test.go
+++ b/pkg/kusionctl/cmd/apply/options_test.go
@@ -116,18 +116,6 @@ func mockCompileWithSpinner() {
 		})
 }
 
-func Test_preview(t *testing.T) {
-	stateStorage := &local.FileSystemState{Path: filepath.Join("", local.KusionState)}
-	t.Run("preview success", func(t *testing.T) {
-		defer monkey.UnpatchAll()
-		mockOperationPreview()
-
-		o := NewApplyOptions()
-		_, err := Preview(o, &fakerRuntime{}, stateStorage, &models.Spec{Resources: []models.Resource{sa1, sa2, sa3}}, project, stack, os.Stdout)
-		assert.Nil(t, err)
-	})
-}
-
 func mockNewKubernetesRuntime() {
 	monkey.Patch(runtime.NewKubernetesRuntime, func() (runtime.Runtime, error) {
 		return &fakerRuntime{}, nil

--- a/pkg/kusionctl/cmd/compile/options.go
+++ b/pkg/kusionctl/cmd/compile/options.go
@@ -2,7 +2,6 @@ package compile
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -11,21 +10,29 @@ import (
 )
 
 type CompileOptions struct {
-	IsCheck     bool
-	Filenames   []string
-	Arguments   []string
-	Settings    []string
+	IsCheck   bool
+	Filenames []string
+	CompileFlags
+}
+
+type CompileFlags struct {
 	Output      string
 	WorkDir     string
+	Settings    []string
+	Arguments   []string
+	Overrides   []string
 	DisableNone bool
 	OverrideAST bool
-	Overrides   []string
 }
 
 func NewCompileOptions() *CompileOptions {
 	return &CompileOptions{
-		Arguments: []string{},
-		Settings:  []string{},
+		Filenames: []string{},
+		CompileFlags: CompileFlags{
+			Settings:  []string{},
+			Arguments: []string{},
+			Overrides: []string{},
+		},
 	}
 }
 
@@ -68,7 +75,7 @@ func (o *CompileOptions) Run() error {
 				o.Output = filepath.Join(o.WorkDir, o.Output)
 			}
 
-			err := ioutil.WriteFile(o.Output, []byte(yaml), 0o666)
+			err := os.WriteFile(o.Output, []byte(yaml), 0o666)
 			if err != nil {
 				return err
 			}

--- a/pkg/kusionctl/cmd/destroy/options.go
+++ b/pkg/kusionctl/cmd/destroy/options.go
@@ -2,6 +2,7 @@ package destroy
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 
@@ -88,7 +89,7 @@ func (o *DestroyOptions) Run() error {
 	}
 
 	// Preview
-	changes.Summary()
+	changes.Summary(os.Stdout)
 
 	// Detail detection
 	if o.Detail {

--- a/pkg/kusionctl/cmd/destroy/options.go
+++ b/pkg/kusionctl/cmd/destroy/options.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/pterm/pterm"
+
 	"kusionstack.io/kusion/pkg/compile"
 	"kusionstack.io/kusion/pkg/engine/backend"
 	"kusionstack.io/kusion/pkg/engine/models"
@@ -33,12 +34,7 @@ type DestroyOptions struct {
 
 func NewDestroyOptions() *DestroyOptions {
 	return &DestroyOptions{
-		CompileOptions: compilecmd.CompileOptions{
-			Filenames: []string{},
-			Arguments: []string{},
-			Settings:  []string{},
-			Overrides: []string{},
-		},
+		CompileOptions: *compilecmd.NewCompileOptions(),
 	}
 }
 

--- a/pkg/kusionctl/cmd/preview/options.go
+++ b/pkg/kusionctl/cmd/preview/options.go
@@ -15,12 +15,7 @@ type PreviewOptions struct {
 
 func NewPreviewOptions() *PreviewOptions {
 	return &PreviewOptions{
-		CompileOptions: compilecmd.CompileOptions{
-			Filenames: []string{},
-			Arguments: []string{},
-			Settings:  []string{},
-			Overrides: []string{},
-		},
+		CompileOptions: *compilecmd.NewCompileOptions(),
 	}
 }
 

--- a/pkg/kusionctl/cmd/preview/options.go
+++ b/pkg/kusionctl/cmd/preview/options.go
@@ -2,7 +2,6 @@ package preview
 
 import (
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/pterm/pterm"
@@ -77,7 +76,7 @@ func (o *PreviewOptions) Run() error {
 		return err
 	}
 
-	changes, err := Preview(o, r, stateStorage, planResources, project, stack, os.Stdout)
+	changes, err := Preview(o, r, stateStorage, planResources, project, stack)
 	if err != nil {
 		return err
 	}
@@ -88,7 +87,7 @@ func (o *PreviewOptions) Run() error {
 	}
 
 	// Summary preview table
-	changes.Summary()
+	changes.Summary(os.Stdout)
 
 	// Detail detection
 	if o.Detail {
@@ -116,7 +115,7 @@ func (o *PreviewOptions) Run() error {
 //
 // Example:
 //
-//	o := NewApplyOptions()
+//	o := NewPreviewOptions()
 //	stateStorage := &states.FileSystemState{
 //	    Path: filepath.Join(o.WorkDir, states.KusionState)
 //	}
@@ -130,8 +129,6 @@ func (o *PreviewOptions) Run() error {
 //	if err != nil {
 //	    return err
 //	}
-//
-// todo @elliotxx io.Writer is not used now
 func Preview(
 	o *PreviewOptions,
 	runtime runtime.Runtime,
@@ -139,7 +136,6 @@ func Preview(
 	planResources *models.Spec,
 	project *projectstack.Project,
 	stack *projectstack.Stack,
-	out io.Writer,
 ) (*opsmodels.Changes, error) {
 	log.Info("Start compute preview changes ...")
 

--- a/pkg/kusionctl/cmd/preview/options.go
+++ b/pkg/kusionctl/cmd/preview/options.go
@@ -7,9 +7,10 @@ import (
 
 type PreviewOptions struct {
 	compilecmd.CompileOptions
-	Yes     bool
-	Detail  bool
-	NoStyle bool
+	Yes          bool
+	Detail       bool
+	NoStyle      bool
+	IgnoreFields []string
 }
 
 func NewPreviewOptions() *PreviewOptions {

--- a/pkg/kusionctl/cmd/preview/options_test.go
+++ b/pkg/kusionctl/cmd/preview/options_test.go
@@ -1,0 +1,132 @@
+//go:build !arm64
+// +build !arm64
+
+package preview
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/stretchr/testify/assert"
+
+	"kusionstack.io/kusion/pkg/engine"
+	"kusionstack.io/kusion/pkg/engine/models"
+	"kusionstack.io/kusion/pkg/engine/operation"
+	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
+	"kusionstack.io/kusion/pkg/engine/operation/types"
+	"kusionstack.io/kusion/pkg/engine/runtime"
+	"kusionstack.io/kusion/pkg/engine/states/local"
+	"kusionstack.io/kusion/pkg/projectstack"
+	"kusionstack.io/kusion/pkg/status"
+)
+
+var (
+	apiVersion = "v1"
+	kind       = "ServiceAccount"
+	namespace  = "test-ns"
+
+	project = &projectstack.Project{
+		ProjectConfiguration: projectstack.ProjectConfiguration{
+			Name:   "testdata",
+			Tenant: "admin",
+		},
+	}
+	stack = &projectstack.Stack{
+		StackConfiguration: projectstack.StackConfiguration{
+			Name: "dev",
+		},
+	}
+
+	sa1 = newSA("sa1")
+	sa2 = newSA("sa2")
+	sa3 = newSA("sa3")
+)
+
+func Test_preview(t *testing.T) {
+	stateStorage := &local.FileSystemState{Path: filepath.Join("", local.KusionState)}
+	t.Run("preview success", func(t *testing.T) {
+		defer monkey.UnpatchAll()
+		mockOperationPreview()
+
+		o := NewPreviewOptions()
+		_, err := Preview(o, &fooRuntime{}, stateStorage, &models.Spec{Resources: []models.Resource{sa1, sa2, sa3}}, project, stack, os.Stdout)
+		assert.Nil(t, err)
+	})
+}
+
+type fooRuntime struct{}
+
+func (f *fooRuntime) Apply(ctx context.Context, request *runtime.ApplyRequest) *runtime.ApplyResponse {
+	return &runtime.ApplyResponse{
+		Resource: request.PlanResource,
+		Status:   nil,
+	}
+}
+
+func (f *fooRuntime) Read(ctx context.Context, request *runtime.ReadRequest) *runtime.ReadResponse {
+	if request.PlanResource.ResourceKey() == "fake-id" {
+		return &runtime.ReadResponse{
+			Resource: nil,
+			Status:   nil,
+		}
+	}
+	return &runtime.ReadResponse{
+		Resource: request.PlanResource,
+		Status:   nil,
+	}
+}
+
+func (f *fooRuntime) Delete(ctx context.Context, request *runtime.DeleteRequest) *runtime.DeleteResponse {
+	return nil
+}
+
+func (f *fooRuntime) Watch(ctx context.Context, request *runtime.WatchRequest) *runtime.WatchResponse {
+	return nil
+}
+
+func mockOperationPreview() {
+	monkey.Patch((*operation.PreviewOperation).Preview,
+		func(*operation.PreviewOperation, *operation.PreviewRequest) (rsp *operation.PreviewResponse, s status.Status) {
+			return &operation.PreviewResponse{
+				Order: &opsmodels.ChangeOrder{
+					StepKeys: []string{sa1.ID, sa2.ID, sa3.ID},
+					ChangeSteps: map[string]*opsmodels.ChangeStep{
+						sa1.ID: {
+							ID:     sa1.ID,
+							Action: types.Create,
+							From:   &sa1,
+						},
+						sa2.ID: {
+							ID:     sa2.ID,
+							Action: types.UnChange,
+							From:   &sa2,
+						},
+						sa3.ID: {
+							ID:     sa3.ID,
+							Action: types.Undefined,
+							From:   &sa1,
+						},
+					},
+				},
+			}, nil
+		},
+	)
+}
+
+func newSA(name string) models.Resource {
+	return models.Resource{
+		ID:   engine.BuildIDForKubernetes(apiVersion, kind, namespace, name),
+		Type: "Kubernetes",
+		Attributes: map[string]interface{}{
+			"apiVersion": apiVersion,
+			"kind":       kind,
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}

--- a/pkg/kusionctl/cmd/preview/options_test.go
+++ b/pkg/kusionctl/cmd/preview/options_test.go
@@ -5,7 +5,6 @@ package preview
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -52,7 +51,7 @@ func Test_preview(t *testing.T) {
 		mockOperationPreview()
 
 		o := NewPreviewOptions()
-		_, err := Preview(o, &fooRuntime{}, stateStorage, &models.Spec{Resources: []models.Resource{sa1, sa2, sa3}}, project, stack, os.Stdout)
+		_, err := Preview(o, &fooRuntime{}, stateStorage, &models.Spec{Resources: []models.Resource{sa1, sa2, sa3}}, project, stack)
 		assert.Nil(t, err)
 	})
 }

--- a/pkg/kusionctl/cmd/preview/preview.go
+++ b/pkg/kusionctl/cmd/preview/preview.go
@@ -59,6 +59,8 @@ func NewCmdPreview() *cobra.Command {
 		i18n.T("Automatically show plan details after previewing it"))
 	cmd.Flags().BoolVarP(&o.NoStyle, "no-style", "", false,
 		i18n.T("no-style sets to RawOutput mode and disables all of styling"))
+	cmd.Flags().StringSliceVarP(&o.IgnoreFields, "ignore-fields", "", nil,
+		i18n.T("Ignore differences of target fields"))
 
 	return cmd
 }

--- a/pkg/kusionctl/cmd/preview/preview.go
+++ b/pkg/kusionctl/cmd/preview/preview.go
@@ -25,7 +25,10 @@ var (
 		kusion preview -D name=test -D age=18
 
 		# Preview with specifying setting file
-		kusion preview -Y settings.yaml`
+		kusion preview -Y settings.yaml
+
+		# Preview with ignored fields
+		kusion preview --ignore-fields="metadata.generation,metadata.managedFields"`
 )
 
 func NewCmdPreview() *cobra.Command {
@@ -45,22 +48,18 @@ func NewCmdPreview() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&o.CompileOptions.WorkDir, "workdir", "w", "",
-		i18n.T("Specify the work directory"))
-	cmd.Flags().StringSliceVarP(&o.CompileOptions.Arguments, "argument", "D", []string{},
-		i18n.T("Specify the arguments to preview KCL"))
-	cmd.Flags().StringSliceVarP(&o.CompileOptions.Settings, "setting", "Y", []string{},
-		i18n.T("Specify the command line setting files"))
-	cmd.Flags().StringSliceVarP(&o.CompileOptions.Overrides, "overrides", "O", []string{},
-		i18n.T("Specify the configuration override path and value"))
-	cmd.Flags().BoolVarP(&o.Yes, "yes", "y", false,
-		i18n.T("Show preview only, no details"))
-	cmd.Flags().BoolVarP(&o.Detail, "detail", "d", false,
-		i18n.T("Automatically show plan details after previewing it"))
-	cmd.Flags().BoolVarP(&o.NoStyle, "no-style", "", false,
-		i18n.T("no-style sets to RawOutput mode and disables all of styling"))
-	cmd.Flags().StringSliceVarP(&o.IgnoreFields, "ignore-fields", "", nil,
-		i18n.T("Ignore differences of target fields"))
+	o.AddCompileFlags(cmd)
+	o.AddPreviewFlags(cmd)
+	o.AddBackendFlags(cmd)
 
 	return cmd
+}
+
+func (o *PreviewOptions) AddPreviewFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.Operator, "operator", "", "",
+		i18n.T("Specify the operator"))
+	cmd.Flags().BoolVarP(&o.Detail, "detail", "d", false,
+		i18n.T("Automatically show plan details after previewing it"))
+	cmd.Flags().StringSliceVarP(&o.IgnoreFields, "ignore-fields", "", nil,
+		i18n.T("Ignore differences of target fields"))
 }

--- a/pkg/kusionctl/cmd/preview/preview_test.go
+++ b/pkg/kusionctl/cmd/preview/preview_test.go
@@ -1,0 +1,15 @@
+package preview
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCmdPreview(t *testing.T) {
+	t.Run("validate error", func(t *testing.T) {
+		cmd := NewCmdPreview()
+		err := cmd.Execute()
+		assert.NotNil(t, err)
+	})
+}


### PR DESCRIPTION
close: #126 

- feat: cmd preview and apply support new flag '--ignore-fields'
- refactor: distinguish compile flags and options
- refactor: move preview logic from `cmd/apply` to `cmd/preview`
- refactor: delete `io.writer` from `func Preview()` and add to `func Summary()`