### PR TITLE
chore: refactor compile flags

### DIFF
--- a/pkg/kusionctl/cmd/apply/apply.go
+++ b/pkg/kusionctl/cmd/apply/apply.go
@@ -56,8 +56,6 @@ func NewCmdApply() *cobra.Command {
 
 	cmd.Flags().BoolVarP(&o.Yes, "yes", "y", false,
 		i18n.T("Automatically approve and perform the update after previewing it"))
-	cmd.Flags().BoolVarP(&o.NoStyle, "no-style", "", false,
-		i18n.T("no-style sets to RawOutput mode and disables all of styling"))
 	cmd.Flags().BoolVarP(&o.DryRun, "dry-run", "", false,
 		i18n.T("dry-run to preview the execution effect (always successful) without actually applying the changes"))
 	cmd.Flags().BoolVarP(&o.Watch, "watch", "", false,

--- a/pkg/kusionctl/cmd/apply/options.go
+++ b/pkg/kusionctl/cmd/apply/options.go
@@ -34,7 +34,6 @@ type ApplyOptions struct {
 
 type ApplyFlag struct {
 	Yes         bool
-	NoStyle     bool
 	DryRun      bool
 	OnlyPreview bool
 	Watch       bool

--- a/pkg/kusionctl/cmd/preview/options.go
+++ b/pkg/kusionctl/cmd/preview/options.go
@@ -30,6 +30,7 @@ type PreviewOptions struct {
 type PreviewFlags struct {
 	Operator     string
 	Detail       bool
+	NoStyle      bool
 	IgnoreFields []string
 }
 
@@ -48,6 +49,12 @@ func (o *PreviewOptions) Validate() error {
 }
 
 func (o *PreviewOptions) Run() error {
+	// Set no style
+	if o.NoStyle {
+		pterm.DisableStyling()
+		pterm.EnableColor()
+	}
+
 	// Parse project and stack of work directory
 	project, stack, err := projectstack.DetectProjectAndStack(o.WorkDir)
 	if err != nil {
@@ -91,8 +98,6 @@ func (o *PreviewOptions) Run() error {
 
 	// Detail detection
 	if o.Detail {
-		changes.OutputDiff("all")
-	} else {
 		for {
 			target, err := changes.PromptDetails()
 			if err != nil {

--- a/pkg/kusionctl/cmd/preview/options_test.go
+++ b/pkg/kusionctl/cmd/preview/options_test.go
@@ -101,6 +101,7 @@ func TestPreviewOptions_Run(t *testing.T) {
 		mockCompileWithSpinner()
 		mockNewKubernetesRuntime()
 		mockOperationPreview()
+		mockPromptDetail("")
 
 		o := NewPreviewOptions()
 		o.Detail = true
@@ -208,5 +209,11 @@ func mockCompileWithSpinner() {
 func mockNewKubernetesRuntime() {
 	monkey.Patch(runtime.NewKubernetesRuntime, func() (runtime.Runtime, error) {
 		return &fooRuntime{}, nil
+	})
+}
+
+func mockPromptDetail(input string) {
+	monkey.Patch((*opsmodels.ChangeOrder).PromptDetails, func(co *opsmodels.ChangeOrder) (string, error) {
+		return input, nil
 	})
 }

--- a/pkg/kusionctl/cmd/preview/preview.go
+++ b/pkg/kusionctl/cmd/preview/preview.go
@@ -60,6 +60,8 @@ func (o *PreviewOptions) AddPreviewFlags(cmd *cobra.Command) {
 		i18n.T("Specify the operator"))
 	cmd.Flags().BoolVarP(&o.Detail, "detail", "d", false,
 		i18n.T("Automatically show plan details after previewing it"))
+	cmd.Flags().BoolVarP(&o.NoStyle, "no-style", "", false,
+		i18n.T("no-style sets to RawOutput mode and disables all of styling"))
 	cmd.Flags().StringSliceVarP(&o.IgnoreFields, "ignore-fields", "", nil,
 		i18n.T("Ignore differences of target fields"))
 }


### PR DESCRIPTION
1. move `--no-style` flag from `ApplyOptions` to `PreviewOptions`
2. default preview result is summary, `--detail` can output details

![image](https://user-images.githubusercontent.com/23924124/201590393-33e4c7a9-58dc-4fa5-b648-f2222493ce37.png)
