### PR TITLE
feat: watch dependents and print them with new console UI

### DIFF
--- a/pkg/engine/operation/watch.go
+++ b/pkg/engine/operation/watch.go
@@ -3,15 +3,14 @@ package operation
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/gosuri/uilive"
+	"github.com/pterm/pterm"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8swatch "k8s.io/apimachinery/pkg/watch"
 
 	"kusionstack.io/kusion/pkg/engine"
-	"kusionstack.io/kusion/pkg/engine/models"
 	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
 	"kusionstack.io/kusion/pkg/engine/printers"
 	"kusionstack.io/kusion/pkg/engine/printers/k8s"
@@ -30,169 +29,121 @@ type WatchRequest struct {
 	opsmodels.Request `json:",inline" yaml:",inline"`
 }
 
-type rowData struct {
-	Type    k8swatch.EventType
-	Message string
-}
-
 func (wo *WatchOperation) Watch(req *WatchRequest) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	resources := req.Spec.Resources
 	// Result channels
-	msgChs := make(map[string]<-chan k8swatch.Event)
+	msgChs := make(map[string][]<-chan k8swatch.Event, len(resources))
 	// Keep sorted
-	ids := make([]string, 0, resources.Len())
-	// Collect watchers and sub watchers
-	collectWatcher := func(res *models.Resource) error {
+	ids := make([]string, resources.Len())
+	// Collect watchers
+	for i := range resources {
+		res := &resources[i]
+		// Get watchers
 		resp := wo.Runtime.Watch(ctx, &runtime.WatchRequest{Resource: res})
 		if status.IsErr(resp.Status) {
 			return fmt.Errorf(resp.Status.String())
 		}
-		ids = append(ids, res.ResourceKey())
-		msgChs[res.ResourceKey()] = resp.ResultCh
-		return nil
+		// Save id
+		ids[i] = res.ResourceKey()
+		// Save channels
+		msgChs[res.ResourceKey()] = resp.ResultChs
 	}
 
-	for i := range resources {
-		if err := collectWatcher(&resources[i]); err != nil {
-			return err
-		}
-
-		// Build sub watcher if had
-		sub, has := hasDependents(&resources[i])
-		if has {
-			if err := collectWatcher(sub); err != nil {
-				return err
-			}
-		}
-	}
-
+	// Console writer
 	writer := uilive.New()
 	writer.RefreshInterval = time.Minute * 1
 	writer.Start()
 	defer writer.Stop()
 
-	table := make(map[string][]rowData, len(msgChs))
+	// Table data
+	tables := make(map[string]*printers.Table, len(ids))
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
-	// Counting ready resource
-	finished := 0
+	// Counting completed resource
+	finished := make(map[string]bool, len(ids))
 	// Start printing
 	for {
 		// Finish watch
-		if finished == len(ids) {
+		if len(finished) == len(ids) {
 			break
 		}
-		for _, key := range ids {
-			ch := msgChs[key]
-			if ch == nil {
+		// Range tables by id
+		for _, id := range ids {
+			chs, ok := msgChs[id]
+			if !ok {
 				continue
 			}
-			select {
-			case e := <-ch:
-				o := e.Object.(*unstructured.Unstructured)
-				var msg string
-				var ready bool
-				if e.Type == k8swatch.Deleted {
-					msg = fmt.Sprintf("%s has beed deleted", o.GetName())
-					ready = true
-				} else {
-					// Restore to actual type
-					target := k8s.Convert(o)
-					msg, ready = tableGenerator.GenerateTable(target)
-				}
-				if ready {
-					msg += fmt.Sprintf("\n%s has been synced already.", key)
-					// Remove watchers
-					msgChs[key] = nil
-					finished++
-				}
 
-				// Save watched data
-				table[key] = append(table[key], rowData{Type: e.Type, Message: msg})
-			case <-ticker.C:
-				// Should never reach
+			// Get or new the target table
+			table, exist := tables[id]
+			if !exist {
+				table = printers.NewTable()
 			}
+
+			// Range channels for each table
+			for _, ch := range chs {
+				select {
+				case e := <-ch:
+					o := e.Object.(*unstructured.Unstructured)
+					var detail string
+					var ready bool
+					if e.Type == k8swatch.Deleted {
+						detail = fmt.Sprintf("%s has beed deleted", o.GetName())
+						ready = true
+					} else {
+						// Restore to actual type
+						target := k8s.Convert(o)
+						detail, ready = tableGenerator.GenerateTable(target)
+					}
+
+					// Mark ready for breaking loop
+					if ready {
+						e.Type = printers.READY
+					}
+
+					// Save watched msg
+					table.InsertOrUpdate(
+						engine.BuildIDForKubernetes(o.GetAPIVersion(), o.GetKind(), o.GetNamespace(), o.GetName()),
+						printers.NewRow(e.Type, o.GetKind(), o.GetName(), detail))
+				case <-ticker.C:
+					// Should never reach
+				}
+			}
+
+			// All channels are isCompleted
+			if table.IsCompleted() {
+				finished[id] = true
+			}
+
+			// Write back
+			tables[id] = table
 		}
-		wo.printTable(writer, ids, table)
+		wo.printTables(writer, ids, tables)
 	}
 	return nil
 }
 
-func (wo *WatchOperation) printTable(w *uilive.Writer, ids []string, table map[string][]rowData) {
+func (wo *WatchOperation) printTables(w *uilive.Writer, ids []string, tables map[string]*printers.Table) {
 	for i, id := range ids {
 		// Print resource Key as heading text
-		fmt.Fprintf(w, "[%s]\n", pretty.CyanBold(id))
+		_, _ = fmt.Fprintf(w, "%s\n", pretty.LightCyanBold("[%s]", id))
 
-		if table[id] == nil {
+		table, ok := tables[id]
+		if !ok {
 			continue
 		}
-		// Print each event as a row
-		for _, row := range table[id] {
-			printRow(w, row)
-		}
+		// Print table
+		data := table.Print()
+		_ = pterm.DefaultTable.WithHasHeader().WithSeparator("  ").WithData(data).WithWriter(w).Render()
 
 		// Split each resource with blank line
 		if i != len(ids)-1 {
-			fmt.Fprintln(w)
+			_, _ = fmt.Fprintln(w)
 		}
 	}
 
-	w.Flush()
-}
-
-func printRow(w io.Writer, row rowData) {
-	eventType := row.Type
-	var eventTypeS string
-	switch eventType {
-	case k8swatch.Added:
-		eventTypeS = pretty.Green(string(eventType))
-	case k8swatch.Deleted:
-		eventTypeS = pretty.Red(string(eventType))
-	case k8swatch.Modified:
-		eventTypeS = pretty.Yellow(string(eventType))
-	case k8swatch.Error:
-		eventTypeS = pretty.Red(string(eventType))
-	default:
-		eventTypeS = pretty.Cyan(string(eventType))
-	}
-	fmt.Fprintf(w, "    [%s] %s\n", eventTypeS, row.Message)
-}
-
-// TODO: refactor me
-func hasDependents(res *models.Resource) (*models.Resource, bool) {
-	// Parse nested field: kind
-	kind, ok, _ := unstructured.NestedString(res.Attributes, "kind")
-	if !ok {
-		return nil, false
-	}
-	switch kind {
-	case k8s.Service:
-		// Endpoints will only be created if the service's selector is not nil
-		selector, _, _ := unstructured.NestedMap(res.Attributes, "spec", "selector")
-		if len(selector) == 0 {
-			return nil, false
-		}
-
-		subKind := k8s.Endpoints
-		apiVersion, _, _ := unstructured.NestedString(res.Attributes, "apiVersion")
-		namespace, _, _ := unstructured.NestedString(res.Attributes, "metadata", "namespace")
-		name, _, _ := unstructured.NestedString(res.Attributes, "metadata", "name")
-		ret := &models.Resource{
-			ID: engine.BuildIDForKubernetes(apiVersion, subKind, namespace, name),
-			Attributes: map[string]interface{}{
-				"apiVersion": apiVersion,
-				"kind":       subKind,
-				"metadata": map[string]string{
-					"namespace": namespace,
-					"name":      name,
-				},
-			},
-		}
-		return ret, true
-	default:
-		return nil, false
-	}
+	_ = w.Flush()
 }

--- a/pkg/engine/operation/watch_test.go
+++ b/pkg/engine/operation/watch_test.go
@@ -70,41 +70,18 @@ func (f *fooWatchRuntime) Delete(ctx context.Context, request *runtime.DeleteReq
 	return nil
 }
 
-var fooNs = map[string]interface{}{
-	"apiVersion": "v1",
-	"kind":       "Namespace",
-	"metadata": map[string]interface{}{
-		"name": "foo",
-	},
-}
-
 func (f *fooWatchRuntime) Watch(ctx context.Context, request *runtime.WatchRequest) *runtime.WatchResponse {
 	out := make(chan k8sWatch.Event)
 	go func() {
-		i := 0
-		for {
-			switch i {
-			case 0:
-				out <- k8sWatch.Event{
-					Type:   k8sWatch.Added,
-					Object: &unstructured.Unstructured{Object: fooNs},
-				}
-				i++
-			case 1:
-				out <- k8sWatch.Event{
-					Type:   k8sWatch.Deleted,
-					Object: &unstructured.Unstructured{Object: barDeployment},
-				}
-				i++
-			default:
-				close(out)
-				return
-			}
+		out <- k8sWatch.Event{
+			Type:   k8sWatch.Deleted,
+			Object: &unstructured.Unstructured{Object: barDeployment},
 		}
+		close(out)
 	}()
 
 	return &runtime.WatchResponse{
-		ResultCh: out,
-		Status:   nil,
+		ResultChs: []<-chan k8sWatch.Event{out},
+		Status:    nil,
 	}
 }

--- a/pkg/engine/printers/table.go
+++ b/pkg/engine/printers/table.go
@@ -1,0 +1,81 @@
+package printers
+
+import (
+	k8swatch "k8s.io/apimachinery/pkg/watch"
+
+	"kusionstack.io/kusion/pkg/util/pretty"
+)
+
+type Table struct {
+	IDs  []string
+	Rows map[string]*Row
+}
+
+type Row struct {
+	Type   k8swatch.EventType
+	Kind   string
+	Name   string
+	Detail string
+}
+
+func NewTable() *Table {
+	return &Table{
+		IDs:  []string{},
+		Rows: map[string]*Row{},
+	}
+}
+
+func NewRow(t k8swatch.EventType, kind, name, detail string) *Row {
+	return &Row{
+		Type:   t,
+		Kind:   kind,
+		Name:   name,
+		Detail: detail,
+	}
+}
+
+const READY k8swatch.EventType = "READY"
+
+func (t *Table) InsertOrUpdate(id string, row *Row) {
+	_, ok := t.Rows[id]
+	if !ok {
+		t.IDs = append(t.IDs, id)
+	}
+	t.Rows[id] = row
+}
+
+func (t *Table) IsCompleted() bool {
+	for _, row := range t.Rows {
+		if row.Type != READY {
+			return false
+		}
+	}
+	return true
+}
+
+func (t *Table) Print() [][]string {
+	data := [][]string{}
+	data = append(data, []string{"Type", "Kind", "Name", "Detail"})
+	for _, id := range t.IDs {
+		row := t.Rows[id]
+		eventType := row.Type
+
+		// Colored type
+		eventTypeS := ""
+		switch eventType {
+		case k8swatch.Added:
+			eventTypeS = pretty.Cyan(string(eventType))
+		case k8swatch.Deleted:
+			eventTypeS = pretty.Red(string(eventType))
+		case k8swatch.Modified:
+			eventTypeS = pretty.Yellow(string(eventType))
+		case k8swatch.Error:
+			eventTypeS = pretty.Red(string(eventType))
+		default:
+			eventTypeS = pretty.Green(string(eventType))
+		}
+
+		data = append(data, []string{eventTypeS, row.Kind, row.Name, row.Detail})
+	}
+	return data
+}

--- a/pkg/engine/runtime/runtime.go
+++ b/pkg/engine/runtime/runtime.go
@@ -89,7 +89,7 @@ type WatchRequest struct {
 }
 
 type WatchResponse struct {
-	ResultCh <-chan watch.Event
+	ResultChs []<-chan watch.Event
 
 	// Status contains messages will show to users
 	Status status.Status


### PR DESCRIPTION
close: https://github.com/KusionStack/kusion/issues/167

main changes:

1. relationships among resources, including ownerRef and selector
2. structured watch data, not flush screen with new message
3. table like UI, print each resource as table and render dynamically

sample:

![imageonline-gifspeed-4243603](https://user-images.githubusercontent.com/23924124/203465888-ad525b85-ec77-4e1e-b284-786a575def5c.gif)
