### PR TITLE
chore: refactor preview flags

### DIFF
--- a/pkg/kusionctl/cmd/destroy/options.go
+++ b/pkg/kusionctl/cmd/destroy/options.go
@@ -57,13 +57,18 @@ func (o *DestroyOptions) Run() error {
 	}
 
 	// Get compile result
-	planResources, sp, err := compile.CompileWithSpinner(o.CompileOptions.WorkDir, o.CompileOptions.Filenames, o.CompileOptions.Settings, o.CompileOptions.Arguments, o.Overrides, stack)
+	planResources, err := compile.GenerateSpec(&compile.Options{
+		WorkDir:     o.WorkDir,
+		Filenames:   o.Filenames,
+		Settings:    o.Settings,
+		Arguments:   o.Arguments,
+		Overrides:   o.Overrides,
+		DisableNone: o.DisableNone,
+		OverrideAST: o.OverrideAST,
+	}, stack)
 	if err != nil {
-		sp.Fail()
 		return err
 	}
-	sp.Success() // Resolve spinner with success message.
-	pterm.Println()
 
 	if planResources == nil || len(planResources.Resources) == 0 {
 		pterm.Println("No resources to destroy")

--- a/pkg/kusionctl/cmd/destroy/options_test.go
+++ b/pkg/kusionctl/cmd/destroy/options_test.go
@@ -6,15 +6,12 @@ package destroy
 import (
 	"context"
 	"errors"
-	"fmt"
 	"path/filepath"
 	"reflect"
 	"testing"
-	"time"
 
 	"bou.ke/monkey"
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/pterm/pterm"
 	"github.com/stretchr/testify/assert"
 
 	"kusionstack.io/kusion/pkg/compile"
@@ -33,7 +30,7 @@ func TestDestroyOptions_Run(t *testing.T) {
 	t.Run("Detail is true", func(t *testing.T) {
 		defer monkey.UnpatchAll()
 		mockDetectProjectAndStack()
-		mockCompileWithSpinner()
+		mockGenerateSpec()
 		mockNewKubernetesRuntime()
 		mockOperationPreview()
 
@@ -46,7 +43,7 @@ func TestDestroyOptions_Run(t *testing.T) {
 	t.Run("prompt no", func(t *testing.T) {
 		defer monkey.UnpatchAll()
 		mockDetectProjectAndStack()
-		mockCompileWithSpinner()
+		mockGenerateSpec()
 		mockNewKubernetesRuntime()
 		mockOperationPreview()
 
@@ -59,7 +56,7 @@ func TestDestroyOptions_Run(t *testing.T) {
 	t.Run("prompt yes", func(t *testing.T) {
 		defer monkey.UnpatchAll()
 		mockDetectProjectAndStack()
-		mockCompileWithSpinner()
+		mockGenerateSpec()
 		mockNewKubernetesRuntime()
 		mockOperationPreview()
 		mockOperationDestroy(opsmodels.Success)
@@ -93,18 +90,10 @@ func mockDetectProjectAndStack() {
 	})
 }
 
-func mockCompileWithSpinner() {
-	monkey.Patch(compile.CompileWithSpinner,
-		func(workDir string, filenames, settings, arguments, overrides []string, stack *projectstack.Stack,
-		) (*models.Spec, *pterm.SpinnerPrinter, error) {
-			sp := pterm.DefaultSpinner.
-				WithSequence("⣾ ", "⣽ ", "⣻ ", "⢿ ", "⡿ ", "⣟ ", "⣯ ", "⣷ ").
-				WithDelay(time.Millisecond * 100)
-
-			sp, _ = sp.Start(fmt.Sprintf("Compiling in stack %s...", stack.Name))
-
-			return &models.Spec{Resources: []models.Resource{sa1}}, sp, nil
-		})
+func mockGenerateSpec() {
+	monkey.Patch(compile.GenerateSpec, func(o *compile.Options, stack *projectstack.Stack) (*models.Spec, error) {
+		return &models.Spec{Resources: []models.Resource{sa1}}, nil
+	})
 }
 
 func Test_preview(t *testing.T) {

--- a/pkg/kusionctl/cmd/preview/options.go
+++ b/pkg/kusionctl/cmd/preview/options.go
@@ -31,6 +31,7 @@ type PreviewOptions struct {
 type PreviewFlags struct {
 	Operator     string
 	Detail       bool
+	All          bool
 	NoStyle      bool
 	IgnoreFields []string
 }
@@ -63,9 +64,17 @@ func (o *PreviewOptions) Run() error {
 	}
 
 	// Get compile result
-	planResources, sp, err := compile.CompileWithSpinner(o.WorkDir, o.Filenames, o.Settings, o.Arguments, o.Overrides, stack)
+	planResources, err := compile.GenerateSpec(&compile.Options{
+		WorkDir:     o.WorkDir,
+		Filenames:   o.Filenames,
+		Settings:    o.Settings,
+		Arguments:   o.Arguments,
+		Overrides:   o.Overrides,
+		DisableNone: o.DisableNone,
+		OverrideAST: o.OverrideAST,
+		NoStyle:     o.NoStyle,
+	}, stack)
 	if err != nil {
-		sp.Fail()
 		return err
 	}
 
@@ -74,9 +83,6 @@ func (o *PreviewOptions) Run() error {
 		fmt.Println(pretty.GreenBold("\nNo resource found in this stack."))
 		return nil
 	}
-
-	sp.Success() // Resolve spinner with success message.
-	pterm.Println()
 
 	// Get state storage from backend config to manage state
 	stateStorage, err := backend.BackendFromConfig(project.Backend, o.BackendOps, o.WorkDir)

--- a/pkg/kusionctl/cmd/preview/options_test.go
+++ b/pkg/kusionctl/cmd/preview/options_test.go
@@ -5,14 +5,11 @@ package preview
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"bou.ke/monkey"
-	"github.com/pterm/pterm"
 	"github.com/stretchr/testify/assert"
 
 	"kusionstack.io/kusion/pkg/compile"
@@ -86,7 +83,7 @@ func TestPreviewOptions_Run(t *testing.T) {
 	t.Run("no changes", func(t *testing.T) {
 		defer monkey.UnpatchAll()
 		mockDetectProjectAndStack()
-		mockCompileWithSpinner()
+		mockGenerateSpec()
 		mockNewKubernetesRuntime()
 
 		o := NewPreviewOptions()
@@ -98,7 +95,7 @@ func TestPreviewOptions_Run(t *testing.T) {
 	t.Run("detail is true", func(t *testing.T) {
 		defer monkey.UnpatchAll()
 		mockDetectProjectAndStack()
-		mockCompileWithSpinner()
+		mockGenerateSpec()
 		mockNewKubernetesRuntime()
 		mockOperationPreview()
 		mockPromptDetail("")
@@ -192,18 +189,10 @@ func mockDetectProjectAndStack() {
 	})
 }
 
-func mockCompileWithSpinner() {
-	monkey.Patch(compile.CompileWithSpinner,
-		func(workDir string, filenames, settings, arguments, overrides []string, stack *projectstack.Stack,
-		) (*models.Spec, *pterm.SpinnerPrinter, error) {
-			sp := pterm.DefaultSpinner.
-				WithSequence("⣾ ", "⣽ ", "⣻ ", "⢿ ", "⡿ ", "⣟ ", "⣯ ", "⣷ ").
-				WithDelay(time.Millisecond * 100)
-
-			sp, _ = sp.Start(fmt.Sprintf("Compiling in stack %s...", stack.Name))
-
-			return &models.Spec{Resources: []models.Resource{sa1, sa2, sa3}}, sp, nil
-		})
+func mockGenerateSpec() {
+	monkey.Patch(compile.GenerateSpec, func(o *compile.Options, stack *projectstack.Stack) (*models.Spec, error) {
+		return &models.Spec{Resources: []models.Resource{sa1, sa2, sa3}}, nil
+	})
 }
 
 func mockNewKubernetesRuntime() {

--- a/pkg/kusionctl/cmd/preview/preview.go
+++ b/pkg/kusionctl/cmd/preview/preview.go
@@ -59,7 +59,9 @@ func (o *PreviewOptions) AddPreviewFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.Operator, "operator", "", "",
 		i18n.T("Specify the operator"))
 	cmd.Flags().BoolVarP(&o.Detail, "detail", "d", false,
-		i18n.T("Automatically show plan details after previewing it"))
+		i18n.T("Automatically show plan details with interactive options"))
+	cmd.Flags().BoolVarP(&o.All, "all", "a", false,
+		i18n.T("Automatically show all plan details, combined use with flag `--detail`"))
 	cmd.Flags().BoolVarP(&o.NoStyle, "no-style", "", false,
 		i18n.T("no-style sets to RawOutput mode and disables all of styling"))
 	cmd.Flags().StringSliceVarP(&o.IgnoreFields, "ignore-fields", "", nil,


### PR DESCRIPTION
1. `kusion preview`: add new flag `--all`, combined with `--detail`, will directly print all diff details without interaction.
2. `kusion apply`: remove useless flag `OnlyPreview`, which is never used.
3. refactor func `CompileWithSpinner()`, make spinner style can be turn on/off by `--no-style`