### PR TITLE
refactor: merge pkg operation/models to operation/types

### DIFF
--- a/pkg/engine/operation/apply.go
+++ b/pkg/engine/operation/apply.go
@@ -5,18 +5,15 @@ import (
 	"fmt"
 	"sync"
 
-	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
-	"kusionstack.io/kusion/third_party/terraform/dag"
-	"kusionstack.io/kusion/third_party/terraform/tfdiags"
-
-	"kusionstack.io/kusion/pkg/engine/operation/graph"
-	"kusionstack.io/kusion/pkg/engine/operation/parser"
-	"kusionstack.io/kusion/pkg/engine/operation/types"
-
 	"kusionstack.io/kusion/pkg/engine/models"
+	"kusionstack.io/kusion/pkg/engine/operation/graph"
+	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
+	"kusionstack.io/kusion/pkg/engine/operation/parser"
 	"kusionstack.io/kusion/pkg/engine/states"
 	"kusionstack.io/kusion/pkg/log"
 	"kusionstack.io/kusion/pkg/status"
+	"kusionstack.io/kusion/third_party/terraform/dag"
+	"kusionstack.io/kusion/third_party/terraform/tfdiags"
 )
 
 type ApplyOperation struct {
@@ -92,7 +89,7 @@ func (ao *ApplyOperation) Apply(request *ApplyRequest) (rsp *ApplyResponse, st s
 
 	applyOperation := &ApplyOperation{
 		Operation: opsmodels.Operation{
-			OperationType:           types.Apply,
+			OperationType:           opsmodels.Apply,
 			StateStorage:            o.StateStorage,
 			CtxResourceIndex:        map[string]*models.Resource{},
 			PriorStateResourceIndex: priorStateResourceIndex,

--- a/pkg/engine/operation/apply_test.go
+++ b/pkg/engine/operation/apply_test.go
@@ -9,20 +9,16 @@ import (
 	"sync"
 	"testing"
 
-	"kusionstack.io/kusion/pkg/engine/states/local"
-
-	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
-
-	"kusionstack.io/kusion/pkg/engine/operation/graph"
-	"kusionstack.io/kusion/pkg/engine/operation/types"
-
 	"bou.ke/monkey"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
 
 	"kusionstack.io/kusion/pkg/engine/models"
+	"kusionstack.io/kusion/pkg/engine/operation/graph"
+	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
 	"kusionstack.io/kusion/pkg/engine/runtime"
 	"kusionstack.io/kusion/pkg/engine/states"
+	"kusionstack.io/kusion/pkg/engine/states/local"
 	"kusionstack.io/kusion/pkg/status"
 )
 
@@ -64,7 +60,7 @@ func Test_validateRequest(t *testing.T) {
 
 func TestOperation_Apply(t *testing.T) {
 	type fields struct {
-		OperationType           types.OperationType
+		OperationType           opsmodels.OperationType
 		StateStorage            states.StateStorage
 		CtxResourceIndex        map[string]*models.Resource
 		PriorStateResourceIndex map[string]*models.Resource
@@ -120,7 +116,7 @@ func TestOperation_Apply(t *testing.T) {
 		{
 			name: "apply test",
 			fields: fields{
-				OperationType: types.Apply,
+				OperationType: opsmodels.Apply,
 				StateStorage:  &local.FileSystemState{Path: filepath.Join("test_data", local.KusionState)},
 				Runtime:       &runtime.KubernetesRuntime{},
 				MsgCh:         make(chan opsmodels.Message, 5),

--- a/pkg/engine/operation/destory.go
+++ b/pkg/engine/operation/destory.go
@@ -5,19 +5,14 @@ import (
 	"fmt"
 	"sync"
 
-	"kusionstack.io/kusion/pkg/engine/operation/graph"
-	"kusionstack.io/kusion/third_party/terraform/dag"
-	"kusionstack.io/kusion/third_party/terraform/tfdiags"
-
-	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
-
-	"kusionstack.io/kusion/pkg/engine/operation/parser"
-	"kusionstack.io/kusion/pkg/engine/operation/types"
-
 	"kusionstack.io/kusion/pkg/engine/models"
-
+	"kusionstack.io/kusion/pkg/engine/operation/graph"
+	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
+	"kusionstack.io/kusion/pkg/engine/operation/parser"
 	"kusionstack.io/kusion/pkg/log"
 	"kusionstack.io/kusion/pkg/status"
+	"kusionstack.io/kusion/third_party/terraform/dag"
+	"kusionstack.io/kusion/third_party/terraform/tfdiags"
 )
 
 type DestroyOperation struct {
@@ -79,7 +74,7 @@ func (do *DestroyOperation) Destroy(request *DestroyRequest) (st status.Status) 
 
 	newDo := &DestroyOperation{
 		Operation: opsmodels.Operation{
-			OperationType:           types.Destroy,
+			OperationType:           opsmodels.Destroy,
 			StateStorage:            o.StateStorage,
 			CtxResourceIndex:        map[string]*models.Resource{},
 			PriorStateResourceIndex: priorStateResourceIndex,

--- a/pkg/engine/operation/destory_test.go
+++ b/pkg/engine/operation/destory_test.go
@@ -9,18 +9,14 @@ import (
 	"path/filepath"
 	"testing"
 
-	"kusionstack.io/kusion/pkg/engine/states/local"
-
-	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
-
-	"kusionstack.io/kusion/pkg/engine/operation/graph"
-	"kusionstack.io/kusion/pkg/engine/operation/types"
-
 	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
 
 	"kusionstack.io/kusion/pkg/engine/models"
+	"kusionstack.io/kusion/pkg/engine/operation/graph"
+	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
 	"kusionstack.io/kusion/pkg/engine/runtime"
+	"kusionstack.io/kusion/pkg/engine/states/local"
 	"kusionstack.io/kusion/pkg/status"
 )
 
@@ -42,7 +38,7 @@ func TestOperation_Destroy(t *testing.T) {
 	mf := &models.Spec{Resources: []models.Resource{resourceState}}
 	o := &DestroyOperation{
 		opsmodels.Operation{
-			OperationType: types.Destroy,
+			OperationType: opsmodels.Destroy,
 			StateStorage:  &local.FileSystemState{Path: filepath.Join("test_data", local.KusionState)},
 			Runtime:       &runtime.KubernetesRuntime{},
 		},

--- a/pkg/engine/operation/graph/executable_node.go
+++ b/pkg/engine/operation/graph/executable_node.go
@@ -1,10 +1,10 @@
 package graph
 
 import (
-	"kusionstack.io/kusion/pkg/engine/operation/models"
+	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
 	"kusionstack.io/kusion/pkg/status"
 )
 
 type ExecutableNode interface {
-	Execute(operation *models.Operation) status.Status
+	Execute(operation *opsmodels.Operation) status.Status
 }

--- a/pkg/engine/operation/graph/resource_node_test.go
+++ b/pkg/engine/operation/graph/resource_node_test.go
@@ -14,7 +14,6 @@ import (
 
 	"kusionstack.io/kusion/pkg/engine/models"
 	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
-	"kusionstack.io/kusion/pkg/engine/operation/types"
 	"kusionstack.io/kusion/pkg/engine/runtime"
 	"kusionstack.io/kusion/pkg/engine/states"
 	"kusionstack.io/kusion/pkg/engine/states/local"
@@ -25,7 +24,7 @@ import (
 func TestResourceNode_Execute(t *testing.T) {
 	type fields struct {
 		BaseNode baseNode
-		Action   types.ActionType
+		Action   opsmodels.ActionType
 		state    *models.Resource
 	}
 	type args struct {
@@ -100,11 +99,11 @@ func TestResourceNode_Execute(t *testing.T) {
 			name: "update",
 			fields: fields{
 				BaseNode: baseNode{ID: Jack},
-				Action:   types.Update,
+				Action:   opsmodels.Update,
 				state:    newResourceState,
 			},
 			args: args{operation: opsmodels.Operation{
-				OperationType:           types.Apply,
+				OperationType:           opsmodels.Apply,
 				StateStorage:            local.NewFileSystemState(),
 				CtxResourceIndex:        priorStateResourceIndex,
 				PriorStateResourceIndex: priorStateResourceIndex,
@@ -121,11 +120,11 @@ func TestResourceNode_Execute(t *testing.T) {
 			name: "delete",
 			fields: fields{
 				BaseNode: baseNode{ID: Jack},
-				Action:   types.Delete,
+				Action:   opsmodels.Delete,
 				state:    newResourceState,
 			},
 			args: args{operation: opsmodels.Operation{
-				OperationType:           types.Apply,
+				OperationType:           opsmodels.Apply,
 				StateStorage:            local.NewFileSystemState(),
 				CtxResourceIndex:        priorStateResourceIndex,
 				PriorStateResourceIndex: priorStateResourceIndex,
@@ -141,11 +140,11 @@ func TestResourceNode_Execute(t *testing.T) {
 			name: "illegalRef",
 			fields: fields{
 				BaseNode: baseNode{ID: Jack},
-				Action:   types.Update,
+				Action:   opsmodels.Update,
 				state:    illegalResourceState,
 			},
 			args: args{operation: opsmodels.Operation{
-				OperationType:           types.Apply,
+				OperationType:           opsmodels.Apply,
 				StateStorage:            local.NewFileSystemState(),
 				CtxResourceIndex:        priorStateResourceIndex,
 				PriorStateResourceIndex: priorStateResourceIndex,

--- a/pkg/engine/operation/models/action.go
+++ b/pkg/engine/operation/models/action.go
@@ -1,4 +1,4 @@
-package types
+package models
 
 import "kusionstack.io/kusion/pkg/util/pretty"
 

--- a/pkg/engine/operation/models/change.go
+++ b/pkg/engine/operation/models/change.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pterm/pterm"
 
 	"kusionstack.io/kusion/pkg/engine/models"
-	"kusionstack.io/kusion/pkg/engine/operation/types"
 	"kusionstack.io/kusion/pkg/log"
 	"kusionstack.io/kusion/pkg/projectstack"
 	"kusionstack.io/kusion/pkg/util/diff"
@@ -18,10 +17,10 @@ import (
 )
 
 type ChangeStep struct {
-	ID     string           // the resource id
-	Action types.ActionType // the operation performed by this step.
-	From   interface{}      // old data
-	To     interface{}      // new data
+	ID     string      // the resource id
+	Action ActionType  // the operation performed by this step.
+	From   interface{} // old data
+	To     interface{} // new data
 }
 
 // Diff compares objects(from and to) which stores in ChangeStep,
@@ -46,12 +45,12 @@ func (cs *ChangeStep) Diff() (string, error) {
 		buf.WriteString(pretty.GreenBold("ID: "))
 		buf.WriteString(pretty.Green("%s\n", cs.ID))
 	}
-	if cs.Action != types.Undefined {
+	if cs.Action != Undefined {
 		buf.WriteString(pretty.GreenBold("Plan: "))
 		buf.WriteString(pterm.Sprintf("%s\n", cs.Action.PrettyString()))
 	}
 	buf.WriteString(pretty.GreenBold("Diff: "))
-	if len(strings.TrimSpace(reportString)) == 0 && cs.Action == types.UnChange {
+	if len(strings.TrimSpace(reportString)) == 0 && cs.Action == UnChange {
 		buf.WriteString(pretty.Gray("<EMPTY>"))
 	} else {
 		buf.WriteString("\n" + strings.TrimSpace(reportString))
@@ -60,7 +59,7 @@ func (cs *ChangeStep) Diff() (string, error) {
 	return buf.String(), nil
 }
 
-func NewChangeStep(id string, op types.ActionType, from, to interface{}) *ChangeStep {
+func NewChangeStep(id string, op ActionType, from, to interface{}) *ChangeStep {
 	return &ChangeStep{
 		ID:     id,
 		Action: op,
@@ -72,10 +71,10 @@ func NewChangeStep(id string, op types.ActionType, from, to interface{}) *Change
 type ChangeStepFilterFunc func(*ChangeStep) bool
 
 var (
-	CreateChangeStepFilter   = func(c *ChangeStep) bool { return c.Action == types.Create }
-	UpdateChangeStepFilter   = func(c *ChangeStep) bool { return c.Action == types.Update }
-	DeleteChangeStepFilter   = func(c *ChangeStep) bool { return c.Action == types.Delete }
-	UnChangeChangeStepFilter = func(c *ChangeStep) bool { return c.Action == types.UnChange }
+	CreateChangeStepFilter   = func(c *ChangeStep) bool { return c.Action == Create }
+	UpdateChangeStepFilter   = func(c *ChangeStep) bool { return c.Action == Update }
+	DeleteChangeStepFilter   = func(c *ChangeStep) bool { return c.Action == Delete }
+	UnChangeChangeStepFilter = func(c *ChangeStep) bool { return c.Action == UnChange }
 )
 
 type Changes struct {
@@ -151,7 +150,7 @@ func (o *ChangeOrder) Diffs() string {
 
 func (p *Changes) AllUnChange() bool {
 	for _, v := range p.ChangeSteps {
-		if v.Action != types.UnChange {
+		if v.Action != UnChange {
 			return false
 		}
 	}

--- a/pkg/engine/operation/models/change_test.go
+++ b/pkg/engine/operation/models/change_test.go
@@ -8,16 +8,15 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"kusionstack.io/kusion/pkg/engine/models"
-	"kusionstack.io/kusion/pkg/engine/operation/types"
 	"kusionstack.io/kusion/pkg/projectstack"
 	"kusionstack.io/kusion/pkg/util/pretty"
 )
 
 var (
-	TestChangeStepOpCreate   = NewChangeStep("id", types.Create, nil, nil)
-	TestChangeStepOpDelete   = NewChangeStep("id", types.Delete, nil, nil)
-	TestChangeStepOpUpdate   = NewChangeStep("id", types.Update, nil, nil)
-	TestChangeStepOpUnChange = NewChangeStep("id", types.UnChange, nil, nil)
+	TestChangeStepOpCreate   = NewChangeStep("id", Create, nil, nil)
+	TestChangeStepOpDelete   = NewChangeStep("id", Delete, nil, nil)
+	TestChangeStepOpUpdate   = NewChangeStep("id", Update, nil, nil)
+	TestChangeStepOpUnChange = NewChangeStep("id", UnChange, nil, nil)
 	TestStepKeys             = []string{"test-key-1", "test-key-2", "test-key-3", "test-key-4"}
 	TestChangeSteps          = map[string]*ChangeStep{
 		"test-key-1": TestChangeStepOpCreate,
@@ -30,27 +29,27 @@ var (
 func TestOpType_Ing(t *testing.T) {
 	tests := []struct {
 		name string
-		op   types.ActionType
+		op   ActionType
 		want string
 	}{
 		{
 			name: "t1",
-			op:   types.Create,
+			op:   Create,
 			want: "Creating",
 		},
 		{
 			name: "t2",
-			op:   types.Delete,
+			op:   Delete,
 			want: "Deleting",
 		},
 		{
 			name: "t3",
-			op:   types.Update,
+			op:   Update,
 			want: "Updating",
 		},
 		{
 			name: "t4",
-			op:   types.UnChange,
+			op:   UnChange,
 			want: "Unchanged",
 		},
 	}
@@ -66,28 +65,28 @@ func TestOpType_Ing(t *testing.T) {
 func TestOpType_PrettyString(t *testing.T) {
 	tests := []struct {
 		name string
-		op   types.ActionType
+		op   ActionType
 		want string
 	}{
 		{
 			name: "t1",
-			op:   types.Create,
-			want: pretty.Green(types.Create.Ing()),
+			op:   Create,
+			want: pretty.Green(Create.Ing()),
 		},
 		{
 			name: "t2",
-			op:   types.Delete,
-			want: pretty.Red(types.Delete.Ing()),
+			op:   Delete,
+			want: pretty.Red(Delete.Ing()),
 		},
 		{
 			name: "t3",
-			op:   types.Update,
-			want: pretty.Blue(types.Update.Ing()),
+			op:   Update,
+			want: pretty.Blue(Update.Ing()),
 		},
 		{
 			name: "t4",
-			op:   types.UnChange,
-			want: pretty.Gray(types.UnChange.Ing()),
+			op:   UnChange,
+			want: pretty.Gray(UnChange.Ing()),
 		},
 	}
 	for _, tt := range tests {
@@ -102,7 +101,7 @@ func TestOpType_PrettyString(t *testing.T) {
 func TestChangeStep_Diff(t *testing.T) {
 	type fields struct {
 		ID  string
-		Op  types.ActionType
+		Op  ActionType
 		Old interface{}
 		New interface{}
 	}
@@ -116,7 +115,7 @@ func TestChangeStep_Diff(t *testing.T) {
 			name: "t1",
 			fields: fields{
 				ID:  "id",
-				Op:  types.Create,
+				Op:  Create,
 				Old: nil,
 				New: nil,
 			},
@@ -472,7 +471,7 @@ func TestChanges_AllUnChange(t *testing.T) {
 			ChangeOrder: &ChangeOrder{
 				ChangeSteps: map[string]*ChangeStep{
 					"foo": {
-						Action: types.Update,
+						Action: Update,
 					},
 				},
 			},
@@ -486,7 +485,7 @@ func TestChanges_AllUnChange(t *testing.T) {
 			ChangeOrder: &ChangeOrder{
 				ChangeSteps: map[string]*ChangeStep{
 					"bar": {
-						Action: types.UnChange,
+						Action: UnChange,
 					},
 				},
 			},

--- a/pkg/engine/operation/models/doc.go
+++ b/pkg/engine/operation/models/doc.go
@@ -1,3 +1,3 @@
-// Package models contains internal models of operations
+// Package models contains internal structs of operations
 // todo CLI imports this package directly. We need to make this pkg internal
 package models

--- a/pkg/engine/operation/models/operation_context.go
+++ b/pkg/engine/operation/models/operation_context.go
@@ -7,7 +7,6 @@ import (
 	"github.com/jinzhu/copier"
 
 	"kusionstack.io/kusion/pkg/engine/models"
-	"kusionstack.io/kusion/pkg/engine/operation/types"
 	"kusionstack.io/kusion/pkg/engine/runtime"
 	"kusionstack.io/kusion/pkg/engine/states"
 	"kusionstack.io/kusion/pkg/log"
@@ -18,7 +17,7 @@ import (
 // Operation is the base model for all operations
 type Operation struct {
 	// OperationType represents the OperationType of this operation
-	OperationType types.OperationType
+	OperationType OperationType
 
 	// StateStorage represents the storage where state will be saved during this operation
 	StateStorage states.StateStorage
@@ -77,15 +76,15 @@ const (
 )
 
 // RefreshResourceIndex refresh resources in CtxResourceIndex & StateResourceIndex
-func (o *Operation) RefreshResourceIndex(resourceKey string, resource *models.Resource, actionType types.ActionType) error {
+func (o *Operation) RefreshResourceIndex(resourceKey string, resource *models.Resource, actionType ActionType) error {
 	o.Lock.Lock()
 	defer o.Lock.Unlock()
 
 	switch actionType {
-	case types.Delete:
+	case Delete:
 		o.CtxResourceIndex[resourceKey] = nil
 		o.StateResourceIndex[resourceKey] = nil
-	case types.Create, types.Update, types.UnChange:
+	case Create, Update, UnChange:
 		o.CtxResourceIndex[resourceKey] = resource
 		o.StateResourceIndex[resourceKey] = resource
 	default:

--- a/pkg/engine/operation/models/operation_type.go
+++ b/pkg/engine/operation/models/operation_type.go
@@ -1,4 +1,4 @@
-package types
+package models
 
 type OperationType int64
 

--- a/pkg/engine/operation/parser/delete_resource_parser.go
+++ b/pkg/engine/operation/parser/delete_resource_parser.go
@@ -3,17 +3,14 @@ package parser
 import (
 	"fmt"
 
-	"kusionstack.io/kusion/pkg/engine/operation/graph"
-	"kusionstack.io/kusion/third_party/terraform/dag"
-
-	"kusionstack.io/kusion/pkg/engine/operation/types"
-
 	"kusionstack.io/kusion/pkg/engine/models"
-
+	"kusionstack.io/kusion/pkg/engine/operation/graph"
+	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
 	"kusionstack.io/kusion/pkg/log"
 	"kusionstack.io/kusion/pkg/status"
 	"kusionstack.io/kusion/pkg/util"
 	"kusionstack.io/kusion/pkg/util/json"
+	"kusionstack.io/kusion/third_party/terraform/dag"
 )
 
 type DeleteResourceParser struct {
@@ -52,7 +49,7 @@ func (d *DeleteResourceParser) Parse(g *dag.AcyclicGraph) (s status.Status) {
 	}
 
 	for key, resource := range resourceIndex {
-		rn, s := graph.NewResourceNode(key, resourceIndex[key], types.Delete)
+		rn, s := graph.NewResourceNode(key, resourceIndex[key], opsmodels.Delete)
 		if status.IsErr(s) {
 			return s
 		}
@@ -73,7 +70,7 @@ func (d *DeleteResourceParser) Parse(g *dag.AcyclicGraph) (s status.Status) {
 
 		// always get the latest vertex in the g.
 		rn = GetVertex(g, rn).(*graph.ResourceNode)
-		s = LinkRefNodes(g, resource.DependsOn, resourceIndex, rn, types.Delete, manifestGraphMap)
+		s = LinkRefNodes(g, resource.DependsOn, resourceIndex, rn, opsmodels.Delete, manifestGraphMap)
 		if status.IsErr(s) {
 			return s
 		}

--- a/pkg/engine/operation/parser/delete_resource_parser_test.go
+++ b/pkg/engine/operation/parser/delete_resource_parser_test.go
@@ -4,10 +4,9 @@ import (
 	"strings"
 	"testing"
 
+	"kusionstack.io/kusion/pkg/engine/models"
 	"kusionstack.io/kusion/pkg/engine/operation/graph"
 	"kusionstack.io/kusion/third_party/terraform/dag"
-
-	"kusionstack.io/kusion/pkg/engine/models"
 )
 
 func TestDeleteResourceParser_Parse(t *testing.T) {

--- a/pkg/engine/operation/parser/parser.go
+++ b/pkg/engine/operation/parser/parser.go
@@ -5,7 +5,7 @@ import (
 
 	"kusionstack.io/kusion/pkg/engine/models"
 	"kusionstack.io/kusion/pkg/engine/operation/graph"
-	"kusionstack.io/kusion/pkg/engine/operation/types"
+	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
 	"kusionstack.io/kusion/pkg/status"
 	"kusionstack.io/kusion/third_party/terraform/dag"
 )
@@ -15,7 +15,7 @@ type Parser interface {
 }
 
 func LinkRefNodes(ag *dag.AcyclicGraph, refNodeKeys []string, resourceIndex map[string]*models.Resource,
-	rn dag.Vertex, defaultAction types.ActionType, manifestGraphMap map[string]interface{},
+	rn dag.Vertex, defaultAction opsmodels.ActionType, manifestGraphMap map[string]interface{},
 ) status.Status {
 	if len(refNodeKeys) == 0 {
 		return nil
@@ -35,7 +35,7 @@ func LinkRefNodes(ag *dag.AcyclicGraph, refNodeKeys []string, resourceIndex map[
 		}
 
 		switch defaultAction {
-		case types.Delete:
+		case opsmodels.Delete:
 			// if the parent node is a deleteNode, we will add an edge from child node to parent node.
 			// if parent node is not a deleteNode and manifestGraph contains parent node,
 			// we will add an edge from parent node to child node

--- a/pkg/engine/operation/parser/spec_parser.go
+++ b/pkg/engine/operation/parser/spec_parser.go
@@ -4,15 +4,13 @@ import (
 	"fmt"
 	"reflect"
 
-	"kusionstack.io/kusion/pkg/engine/operation/graph"
-	"kusionstack.io/kusion/third_party/terraform/dag"
-
-	"kusionstack.io/kusion/pkg/engine/operation/types"
-
 	"kusionstack.io/kusion/pkg/engine/models"
+	"kusionstack.io/kusion/pkg/engine/operation/graph"
+	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
 	"kusionstack.io/kusion/pkg/status"
 	"kusionstack.io/kusion/pkg/util"
 	"kusionstack.io/kusion/pkg/util/json"
+	"kusionstack.io/kusion/third_party/terraform/dag"
 )
 
 type SpecParser struct {
@@ -39,7 +37,7 @@ func (m *SpecParser) Parse(g *dag.AcyclicGraph) (s status.Status) {
 	util.CheckNotNil(root, fmt.Sprintf("No root in this DAG:%s", json.Marshal2String(g)))
 	resourceIndex := sp.Resources.Index()
 	for key, resourceState := range resourceIndex {
-		rn, s := graph.NewResourceNode(key, resourceIndex[key], types.Update)
+		rn, s := graph.NewResourceNode(key, resourceIndex[key], opsmodels.Update)
 		if status.IsErr(s) {
 			return s
 		}
@@ -70,7 +68,7 @@ func (m *SpecParser) Parse(g *dag.AcyclicGraph) (s status.Status) {
 		refNodeKeys = Deduplicate(refNodeKeys)
 
 		// linkRefNodes
-		s = LinkRefNodes(g, refNodeKeys, resourceIndex, rn, types.Update, nil)
+		s = LinkRefNodes(g, refNodeKeys, resourceIndex, rn, opsmodels.Update, nil)
 		if status.IsErr(s) {
 			return s
 		}

--- a/pkg/engine/operation/preview.go
+++ b/pkg/engine/operation/preview.go
@@ -5,18 +5,14 @@ import (
 	"fmt"
 	"sync"
 
-	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
-	"kusionstack.io/kusion/third_party/terraform/dag"
-	"kusionstack.io/kusion/third_party/terraform/tfdiags"
-
-	"kusionstack.io/kusion/pkg/engine/operation/graph"
-	"kusionstack.io/kusion/pkg/engine/operation/types"
-
 	"kusionstack.io/kusion/pkg/engine/models"
-
+	"kusionstack.io/kusion/pkg/engine/operation/graph"
+	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
 	"kusionstack.io/kusion/pkg/engine/states"
 	"kusionstack.io/kusion/pkg/log"
 	"kusionstack.io/kusion/pkg/status"
+	"kusionstack.io/kusion/third_party/terraform/dag"
+	"kusionstack.io/kusion/third_party/terraform/tfdiags"
 )
 
 type PreviewOperation struct {
@@ -65,10 +61,10 @@ func (po *PreviewOperation) Preview(request *PreviewRequest) (rsp *PreviewRespon
 	priorState, resultState = po.InitStates(&request.Request)
 
 	switch o.OperationType {
-	case types.ApplyPreview:
+	case opsmodels.ApplyPreview:
 		priorStateResourceIndex = priorState.Resources.Index()
 		ag, s = NewApplyGraph(request.Spec, priorState)
-	case types.DestroyPreview:
+	case opsmodels.DestroyPreview:
 		resources := request.Request.Spec.Resources
 		priorStateResourceIndex = resources.Index()
 		ag, s = NewDestroyGraph(resources)

--- a/pkg/engine/operation/preview_test.go
+++ b/pkg/engine/operation/preview_test.go
@@ -9,7 +9,6 @@ import (
 
 	"kusionstack.io/kusion/pkg/engine/models"
 	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
-	"kusionstack.io/kusion/pkg/engine/operation/types"
 	"kusionstack.io/kusion/pkg/engine/runtime"
 	"kusionstack.io/kusion/pkg/engine/states"
 	"kusionstack.io/kusion/pkg/engine/states/local"
@@ -78,7 +77,7 @@ func (f *fakePreviewRuntime) Watch(ctx context.Context, request *runtime.WatchRe
 func TestOperation_Preview(t *testing.T) {
 	defer os.Remove("kusion_state.json")
 	type fields struct {
-		OperationType           types.OperationType
+		OperationType           opsmodels.OperationType
 		StateStorage            states.StateStorage
 		CtxResourceIndex        map[string]*models.Resource
 		PriorStateResourceIndex map[string]*models.Resource
@@ -102,7 +101,7 @@ func TestOperation_Preview(t *testing.T) {
 		{
 			name: "success-when-apply",
 			fields: fields{
-				OperationType: types.ApplyPreview,
+				OperationType: opsmodels.ApplyPreview,
 				Runtime:       &fakePreviewRuntime{},
 				StateStorage:  &local.FileSystemState{Path: local.KusionState},
 				Order:         &opsmodels.ChangeOrder{StepKeys: []string{}, ChangeSteps: map[string]*opsmodels.ChangeStep{}},
@@ -128,7 +127,7 @@ func TestOperation_Preview(t *testing.T) {
 					ChangeSteps: map[string]*opsmodels.ChangeStep{
 						"fake-id": {
 							ID:     "fake-id",
-							Action: types.Create,
+							Action: opsmodels.Create,
 							From:   (*models.Resource)(nil),
 							To:     &FakeResourceState,
 						},
@@ -140,7 +139,7 @@ func TestOperation_Preview(t *testing.T) {
 		{
 			name: "success-when-destroy",
 			fields: fields{
-				OperationType: types.DestroyPreview,
+				OperationType: opsmodels.DestroyPreview,
 				Runtime:       &fakePreviewRuntime{},
 				StateStorage:  &local.FileSystemState{Path: local.KusionState},
 				Order:         &opsmodels.ChangeOrder{},
@@ -166,7 +165,7 @@ func TestOperation_Preview(t *testing.T) {
 					ChangeSteps: map[string]*opsmodels.ChangeStep{
 						"fake-id-2": {
 							ID:     "fake-id-2",
-							Action: types.Delete,
+							Action: opsmodels.Delete,
 							From:   &FakeResourceState2,
 							To:     (*models.Resource)(nil),
 						},
@@ -178,7 +177,7 @@ func TestOperation_Preview(t *testing.T) {
 		{
 			name: "fail-because-empty-models",
 			fields: fields{
-				OperationType: types.ApplyPreview,
+				OperationType: opsmodels.ApplyPreview,
 				Runtime:       &fakePreviewRuntime{},
 				StateStorage:  &local.FileSystemState{Path: local.KusionState},
 				Order:         &opsmodels.ChangeOrder{},
@@ -196,7 +195,7 @@ func TestOperation_Preview(t *testing.T) {
 		{
 			name: "fail-because-nonexistent-id",
 			fields: fields{
-				OperationType: types.ApplyPreview,
+				OperationType: opsmodels.ApplyPreview,
 				Runtime:       &fakePreviewRuntime{},
 				StateStorage:  &local.FileSystemState{Path: local.KusionState},
 				Order:         &opsmodels.ChangeOrder{},

--- a/pkg/kusionctl/cmd/apply/options.go
+++ b/pkg/kusionctl/cmd/apply/options.go
@@ -16,7 +16,6 @@ import (
 	"kusionstack.io/kusion/pkg/engine/models"
 	"kusionstack.io/kusion/pkg/engine/operation"
 	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
-	"kusionstack.io/kusion/pkg/engine/operation/types"
 	"kusionstack.io/kusion/pkg/engine/runtime"
 	runtimeInit "kusionstack.io/kusion/pkg/engine/runtime/init"
 	"kusionstack.io/kusion/pkg/engine/states"
@@ -246,7 +245,7 @@ func Apply(
 				switch msg.OpResult {
 				case opsmodels.Success, opsmodels.Skip:
 					var title string
-					if changeStep.Action == types.UnChange {
+					if changeStep.Action == opsmodels.UnChange {
 						title = fmt.Sprintf("%s %s, %s",
 							changeStep.Action.String(),
 							pterm.Bold.Sprint(changeStep.ID),
@@ -348,7 +347,7 @@ func Watch(o *ApplyOptions,
 	// Filter out unchanged resources
 	toBeWatched := models.Resources{}
 	for _, res := range planResources.Resources {
-		if changes.ChangeOrder.ChangeSteps[res.ResourceKey()].Action != types.UnChange {
+		if changes.ChangeOrder.ChangeSteps[res.ResourceKey()].Action != opsmodels.UnChange {
 			toBeWatched = append(toBeWatched, res)
 		}
 	}
@@ -373,20 +372,20 @@ type lineSummary struct {
 	created, updated, deleted int
 }
 
-func (ls *lineSummary) Count(op types.ActionType) {
+func (ls *lineSummary) Count(op opsmodels.ActionType) {
 	switch op {
-	case types.Create:
+	case opsmodels.Create:
 		ls.created++
-	case types.Update:
+	case opsmodels.Update:
 		ls.updated++
-	case types.Delete:
+	case opsmodels.Delete:
 		ls.deleted++
 	}
 }
 
 func allUnChange(changes *opsmodels.Changes) bool {
 	for _, v := range changes.ChangeSteps {
-		if v.Action != types.UnChange {
+		if v.Action != opsmodels.UnChange {
 			return false
 		}
 	}

--- a/pkg/kusionctl/cmd/apply/options_test.go
+++ b/pkg/kusionctl/cmd/apply/options_test.go
@@ -20,7 +20,6 @@ import (
 	"kusionstack.io/kusion/pkg/engine/models"
 	"kusionstack.io/kusion/pkg/engine/operation"
 	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
-	"kusionstack.io/kusion/pkg/engine/operation/types"
 	"kusionstack.io/kusion/pkg/engine/runtime"
 	"kusionstack.io/kusion/pkg/engine/states/local"
 	"kusionstack.io/kusion/pkg/projectstack"
@@ -134,17 +133,17 @@ func mockOperationPreview() {
 					ChangeSteps: map[string]*opsmodels.ChangeStep{
 						sa1.ID: {
 							ID:     sa1.ID,
-							Action: types.Create,
+							Action: opsmodels.Create,
 							From:   &sa1,
 						},
 						sa2.ID: {
 							ID:     sa2.ID,
-							Action: types.UnChange,
+							Action: opsmodels.UnChange,
 							From:   &sa2,
 						},
 						sa3.ID: {
 							ID:     sa3.ID,
-							Action: types.Undefined,
+							Action: opsmodels.Undefined,
 							From:   &sa1,
 						},
 					},
@@ -192,7 +191,7 @@ func Test_apply(t *testing.T) {
 			ChangeSteps: map[string]*opsmodels.ChangeStep{
 				sa1.ID: {
 					ID:     sa1.ID,
-					Action: types.Create,
+					Action: opsmodels.Create,
 					From:   sa1,
 				},
 			},
@@ -214,12 +213,12 @@ func Test_apply(t *testing.T) {
 			ChangeSteps: map[string]*opsmodels.ChangeStep{
 				sa1.ID: {
 					ID:     sa1.ID,
-					Action: types.Create,
+					Action: opsmodels.Create,
 					From:   &sa1,
 				},
 				sa2.ID: {
 					ID:     sa2.ID,
-					Action: types.UnChange,
+					Action: opsmodels.UnChange,
 					From:   &sa2,
 				},
 			},
@@ -240,7 +239,7 @@ func Test_apply(t *testing.T) {
 			ChangeSteps: map[string]*opsmodels.ChangeStep{
 				sa1.ID: {
 					ID:     sa1.ID,
-					Action: types.Create,
+					Action: opsmodels.Create,
 					From:   &sa1,
 				},
 			},

--- a/pkg/kusionctl/cmd/destroy/options.go
+++ b/pkg/kusionctl/cmd/destroy/options.go
@@ -14,7 +14,6 @@ import (
 	"kusionstack.io/kusion/pkg/engine/models"
 	"kusionstack.io/kusion/pkg/engine/operation"
 	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
-	"kusionstack.io/kusion/pkg/engine/operation/types"
 	"kusionstack.io/kusion/pkg/engine/runtime"
 	runtimeInit "kusionstack.io/kusion/pkg/engine/runtime/init"
 	"kusionstack.io/kusion/pkg/engine/states"
@@ -145,7 +144,7 @@ func (o *DestroyOptions) preview(planResources *models.Spec,
 
 	pc := &operation.PreviewOperation{
 		Operation: opsmodels.Operation{
-			OperationType: types.DestroyPreview,
+			OperationType: opsmodels.DestroyPreview,
 			Runtime:       runtime,
 			StateStorage:  stateStorage,
 			ChangeOrder:   &opsmodels.ChangeOrder{StepKeys: []string{}, ChangeSteps: map[string]*opsmodels.ChangeStep{}},
@@ -212,7 +211,7 @@ func (o *DestroyOptions) destroy(planResources *models.Spec, changes *opsmodels.
 				switch msg.OpResult {
 				case opsmodels.Success, opsmodels.Skip:
 					var title string
-					if changeStep.Action == types.UnChange {
+					if changeStep.Action == opsmodels.UnChange {
 						title = fmt.Sprintf("%s %s, %s",
 							changeStep.Action.String(),
 							pterm.Bold.Sprint(changeStep.ID),

--- a/pkg/kusionctl/cmd/destroy/options_test.go
+++ b/pkg/kusionctl/cmd/destroy/options_test.go
@@ -19,7 +19,6 @@ import (
 	"kusionstack.io/kusion/pkg/engine/models"
 	"kusionstack.io/kusion/pkg/engine/operation"
 	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
-	"kusionstack.io/kusion/pkg/engine/operation/types"
 	"kusionstack.io/kusion/pkg/engine/runtime"
 	"kusionstack.io/kusion/pkg/engine/states/local"
 	"kusionstack.io/kusion/pkg/projectstack"
@@ -156,7 +155,7 @@ func mockOperationPreview() {
 					ChangeSteps: map[string]*opsmodels.ChangeStep{
 						sa1.ID: {
 							ID:     sa1.ID,
-							Action: types.Delete,
+							Action: opsmodels.Delete,
 							From:   nil,
 						},
 					},
@@ -205,12 +204,12 @@ func Test_destroy(t *testing.T) {
 			ChangeSteps: map[string]*opsmodels.ChangeStep{
 				sa1.ID: {
 					ID:     sa1.ID,
-					Action: types.Delete,
+					Action: opsmodels.Delete,
 					From:   nil,
 				},
 				sa2.ID: {
 					ID:     sa2.ID,
-					Action: types.UnChange,
+					Action: opsmodels.UnChange,
 					From:   &sa2,
 				},
 			},
@@ -234,7 +233,7 @@ func Test_destroy(t *testing.T) {
 			ChangeSteps: map[string]*opsmodels.ChangeStep{
 				sa1.ID: {
 					ID:     sa1.ID,
-					Action: types.Delete,
+					Action: opsmodels.Delete,
 					From:   nil,
 				},
 			},

--- a/pkg/kusionctl/cmd/preview/options.go
+++ b/pkg/kusionctl/cmd/preview/options.go
@@ -11,7 +11,6 @@ import (
 	"kusionstack.io/kusion/pkg/engine/models"
 	"kusionstack.io/kusion/pkg/engine/operation"
 	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
-	"kusionstack.io/kusion/pkg/engine/operation/types"
 	"kusionstack.io/kusion/pkg/engine/runtime"
 	runtimeInit "kusionstack.io/kusion/pkg/engine/runtime/init"
 	"kusionstack.io/kusion/pkg/engine/states"
@@ -167,7 +166,7 @@ func Preview(
 	// Construct the preview operation
 	pc := &operation.PreviewOperation{
 		Operation: opsmodels.Operation{
-			OperationType: types.ApplyPreview,
+			OperationType: opsmodels.ApplyPreview,
 			Runtime:       runtime,
 			StateStorage:  storage,
 			IgnoreFields:  o.IgnoreFields,

--- a/pkg/kusionctl/cmd/preview/options_test.go
+++ b/pkg/kusionctl/cmd/preview/options_test.go
@@ -17,7 +17,6 @@ import (
 	"kusionstack.io/kusion/pkg/engine/models"
 	"kusionstack.io/kusion/pkg/engine/operation"
 	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
-	"kusionstack.io/kusion/pkg/engine/operation/types"
 	"kusionstack.io/kusion/pkg/engine/runtime"
 	"kusionstack.io/kusion/pkg/engine/states/local"
 	"kusionstack.io/kusion/pkg/projectstack"
@@ -146,17 +145,17 @@ func mockOperationPreview() {
 					ChangeSteps: map[string]*opsmodels.ChangeStep{
 						sa1.ID: {
 							ID:     sa1.ID,
-							Action: types.Create,
+							Action: opsmodels.Create,
 							From:   &sa1,
 						},
 						sa2.ID: {
 							ID:     sa2.ID,
-							Action: types.UnChange,
+							Action: opsmodels.UnChange,
 							From:   &sa2,
 						},
 						sa3.ID: {
 							ID:     sa3.ID,
-							Action: types.Undefined,
+							Action: opsmodels.Undefined,
 							From:   &sa1,
 						},
 					},


### PR DESCRIPTION
Pkg `operation` has two sub pkg, `models` and `types`, they are written for same usages, so merge them to one pkg.

For avoiding import path collision, takes `types` as the final choice.

This PR changes 20+ files, mostly changes are `import` path and format. 
