### PR TITLE
fix makefile

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -21,7 +21,5 @@ jobs:
           go-version: 1.18
       - name: Setup K3d
         uses: nolar/setup-k3d-k3s@v1.0.8
-      - run: make build-local-ubuntu-all
-      - run: echo "${PWD}/_build/bundles/kusion-ubuntu/kclvm/bin" >> $GITHUB_PATH
       - name: run e2e
         run: make e2e-test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,12 +20,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.18
-
-      - run: make build-local-ubuntu-all
-      - run: echo "${PWD}/_build/bundles/kusion-ubuntu/kclvm/bin" >> $GITHUB_PATH
-      - run: which kclvm
-      - run: go run ./scripts/install-kcl-go kcl
-
       - name: Running go tests with coverage
         env:
           GO111MODULE: on

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,11 +22,6 @@ jobs:
         with:
           go-version: 1.18
 
-      - run: make build-local-ubuntu-all
-      - run: echo "${PWD}/_build/bundles/kusion-ubuntu/kclvm/bin" >> $GITHUB_PATH
-      - run: which kclvm
-      - run: go run ./scripts/install-kcl-go kcl
-
       - run: go build ./...
       - run: go vet ./...
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,14 @@
 FROM ubuntu:20.04
 
-COPY _build/bundles/kusion-ubuntu/ /kusion/
+COPY _build/bundles/kusion-linux/ /kusion/
 
-RUN chmod +x /kusion/bin/kusion \
-&&  chmod +x /kusion/bin/kcl-openapi \
-&&  chmod +x /kusion/kclvm/bin/kcl \
-&&  chmod +x /kusion/kclvm/bin/kclvm \
-&&  chmod +x /kusion/kclvm/bin/kcl-doc \
-&&  chmod +x /kusion/kclvm/bin/kcl-plugin \
-&&  chmod +x /kusion/kclvm/bin/kcl-test \
-&&  chmod +x /kusion/kclvm/bin/kcl-lint \
-&&  chmod +x /kusion/kclvm/bin/kcl-fmt \
-&&  chmod +x /kusion/kclvm/bin/kcl-vet \
-&&  chmod +x /kusion/kclvm/bin/kcl-go \
-&&  chmod +x /kusion/kclvm/bin/kclvm_cli
+RUN chmod +x /kusion/bin/kusion
 
 # Install KCL Dependencies
 RUN apt-get update -y && apt-get install python3 python3-pip -y
-RUN /kusion/kclvm/bin/kcl
+# unembed kcl stuff
+RUN /kusion/bin/kusion
 
-ENV PATH="/kusion/bin:/kusion/kclvm/bin:${PATH}"
+ENV PATH="/kusion/bin:/root/go/bin:${PATH}"
 ENV KUSION_PATH="/kusion"
 ENV LANG=en_US.utf8

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 SHELL = /bin/bash
 PWD:=$(shell pwd)
 
-# todo
-KCLVM_BUILDER:=reg.docker.kusionstack.io.com/kusion/kclvm-builder
+KCLVM_BUILDER:=kusionstack/kclvm-builder
 
 RUN_IN_DOCKER:=docker run -it --rm
 RUN_IN_DOCKER+=-v ~/.ssh:/root/.ssh
@@ -65,64 +64,23 @@ clean:  ## Clean build bundles
 	-rm -f ./pkg/version/z_update_version.go
 	-rm -rf ./_build/bundles
 
-# todo: fix macOS-arm64 and windows build
 build-all: build-local-darwin-all build-local-ubuntu-all build-local-centos-all build-local-darwin-arm64-all build-local-windows-all ## Build all platforms (darwin, linux, windows)
-
-build-local-kusion-darwin:  ## Build kusionctl only for macOS
-	# Delete old artifacts
-	-rm -f ./pkg/version/z_update_version.go
-	-rm -rf ./_build/bundles/kusion-darwin/bin/kusion
-	# Update version
-	go generate ./pkg/version
-	# Build kusion
-	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 \
-		go build -o ./_build/bundles/kusion-darwin/bin/kusion \
-		-ldflags="-s -w" .
 
 build-local-darwin:  ## Build kusion tool chain for macOS
 	# Delete old artifacts
 	-rm -f ./pkg/version/z_update_version.go
 	-rm -rf ./_build/bundles/kusion-darwin
-	mkdir -p ./_build/bundles/kusion-darwin/bin
-	mkdir -p ./_build/bundles/kusion-darwin/kclvm/bin
 	# Update version
 	go generate ./pkg/version
-
 	# Build kusion
 	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 \
 		go build -o ./_build/bundles/kusion-darwin/bin/kusion \
 		-ldflags="-s -w" .
 
 build-local-darwin-all: build-local-darwin ## Build kusion & kcl tool chain for macOS
-	# Install kclvm darwin
-	go run ./scripts/install-kclvm \
-		--triple=Darwin \
-		--mirrors=${KCLVM_URL_BASE_MIRRORS} \
-		--outdir=./_build/bundles/kusion-darwin/kclvm
-
-	# Build kcl-go
-	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 \
-		go build -o ${PWD}/_build/bundles/kusion-darwin/kclvm/bin/kcl-go \
-		./scripts/install-kcl-go
-
 	# Build kcl-openapi
 	cd ./scripts/install-kcl-openapi && GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 \
 		go build -o ${PWD}/_build/bundles/kusion-darwin/bin/kcl-openapi
-
-	# chmod +x
-	-chmod +x ./_build/bundles/kusion-darwin/bin/kusion
-	-chmod +x ./_build/bundles/kusion-darwin/bin/kcl-openapi
-	-chmod +x ./_build/bundles/kusion-darwin/kclvm/bin/kcl
-	-chmod +x ./_build/bundles/kusion-darwin/kclvm/bin/kclvm
-	-chmod +x ./_build/bundles/kusion-darwin/kclvm/bin/kcl-plugin
-	-chmod +x ./_build/bundles/kusion-darwin/kclvm/bin/kcl-doc
-	-chmod +x ./_build/bundles/kusion-darwin/kclvm/bin/kcl-test
-	-chmod +x ./_build/bundles/kusion-darwin/kclvm/bin/kcl-lint
-	-chmod +x ./_build/bundles/kusion-darwin/kclvm/bin/kcl-fmt
-	-chmod +x ./_build/bundles/kusion-darwin/kclvm/bin/kcl-vet
-	-chmod +x ./_build/bundles/kusion-darwin/kclvm/bin/kcl-go
-	-chmod +x ./_build/bundles/kusion-darwin/kclvm/bin/kclvm_cli
-	-chmod +x ./_build/bundles/kusion-darwin/kclvm/tools/clang/bin/clang
 
 	# Copy docs
 	cp -r ./docs ./_build/bundles/kusion-darwin/docs
@@ -149,35 +107,9 @@ build-local-darwin-arm64: ## Build kusion tool chain for macOS arm64
 		-ldflags="-s -w" .
 
 build-local-darwin-arm64-all: build-local-darwin-arm64 ## Build kusion & kcl tool chain for macOS arm64
-	# Install kclvm darwin
-	go run ./scripts/install-kclvm \
-		--triple=Darwin-arm64 \
-		--mirrors=${KCLVM_URL_BASE_MIRRORS} \
-		--outdir=./_build/bundles/kusion-darwin-arm64/kclvm
-
-	# Build kcl-go
-	GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 \
-		go build -o ${PWD}/_build/bundles/kusion-darwin-arm64/kclvm/bin/kcl-go \
-		./scripts/install-kcl-go
-
 	# Build kcl-openapi
 	cd ./scripts/install-kcl-openapi && GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 \
 		go build -o ${PWD}/_build/bundles/kusion-darwin-arm64/bin/kcl-openapi
-
-	# chmod +x
-	-chmod +x ./_build/bundles/kusion-darwin-arm64/bin/kusion
-	-chmod +x ./_build/bundles/kusion-darwin-arm64/bin/kcl-openapi
-	-chmod +x ./_build/bundles/kusion-darwin-arm64/kclvm/bin/kcl
-	-chmod +x ./_build/bundles/kusion-darwin-arm64/kclvm/bin/kclvm
-	-chmod +x ./_build/bundles/kusion-darwin-arm64/kclvm/bin/kcl-plugin
-	-chmod +x ./_build/bundles/kusion-darwin-arm64/kclvm/bin/kcl-doc
-	-chmod +x ./_build/bundles/kusion-darwin-arm64/kclvm/bin/kcl-test
-	-chmod +x ./_build/bundles/kusion-darwin-arm64/kclvm/bin/kcl-lint
-	-chmod +x ./_build/bundles/kusion-darwin-arm64/kclvm/bin/kcl-fmt
-	-chmod +x ./_build/bundles/kusion-darwin-arm64/kclvm/bin/kcl-vet
-	-chmod +x ./_build/bundles/kusion-darwin-arm64/kclvm/bin/kcl-go
-	-chmod +x ./_build/bundles/kusion-darwin-arm64/kclvm/bin/kclvm_cli
-	-chmod +x ./_build/bundles/kusion-darwin-arm64/kclvm/tools/clang/bin/clang
 
 	# Copy docs
 	cp -r ./docs ./_build/bundles/kusion-darwin-arm64/docs
@@ -208,97 +140,23 @@ build-local-linux:  ## Build kusion tool chain for linux
 		go build -o ./_build/bundles/kusion-linux/bin/kusion \
 		-ldflags="-s -w" .
 
-build-local-linux-all:
-	@echo -e "$(CCRED)**** The use of build-local-linux-alle is deprecated. Use build-local-ubuntu-all or build-local-centos-all instead. ****$(CCEND)"
-	$(MAKE) build-local-ubuntu-all
-
-build-local-ubuntu-all: build-local-linux  ## Build kusion & kcl tool chain for ubuntu
-	# Install kclvm ubuntu
-	go run ./scripts/install-kclvm \
-		--triple=ubuntu \
-		--mirrors=${KCLVM_URL_BASE_MIRRORS} \
-		--outdir=./_build/bundles/kusion-ubuntu/kclvm
-
-	# Build kcl-go
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
-		go build -o ${PWD}/_build/bundles/kusion-ubuntu/kclvm/bin/kcl-go \
-		./scripts/install-kcl-go
-
+build-local-linux-all: build-local-linux  ## Build kusion & kcl tool chain for linux
 	# Build kcl-openapi
 	cd ./scripts/install-kcl-openapi && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
-		go build -o ${PWD}/_build/bundles/kusion-ubuntu/bin/kcl-openapi
-
-	# chmod +x
-	-chmod +x ./_build/bundles/kusion-linux/bin/kusion
-	-chmod +x ./_build/bundles/kusion-ubuntu/bin/kcl-openapi
-	-chmod +x ./_build/bundles/kusion-ubuntu/kclvm/bin/kcl
-	-chmod +x ./_build/bundles/kusion-ubuntu/kclvm/bin/kclvm
-	-chmod +x ./_build/bundles/kusion-ubuntu/kclvm/bin/kcl-plugin
-	-chmod +x ./_build/bundles/kusion-ubuntu/kclvm/bin/kcl-doc
-	-chmod +x ./_build/bundles/kusion-ubuntu/kclvm/bin/kcl-test
-	-chmod +x ./_build/bundles/kusion-ubuntu/kclvm/bin/kcl-lint
-	-chmod +x ./_build/bundles/kusion-ubuntu/kclvm/bin/kcl-fmt
-	-chmod +x ./_build/bundles/kusion-ubuntu/kclvm/bin/kcl-vet
-	-chmod +x ./_build/bundles/kusion-ubuntu/kclvm/bin/kcl-go
-	-chmod +x ./_build/bundles/kusion-ubuntu/kclvm/bin/kclvm_cli
-	# linux use native clang and need not chmod
+		go build -o ${PWD}/_build/bundles/kusion-linux/bin/kcl-openapi
 
 	# Copy docs
-	cp -r ./docs ./_build/bundles/kusion-ubuntu/docs
+	cp -r ./docs ./_build/bundles/kusion-linux/docs
 
 	# Copy README.md
-	cp ./README.md ./_build/bundles/kusion-ubuntu
+	cp ./README.md ./_build/bundles/kusion-linux
 
 	# Copy kusion
-	cp -r ./_build/bundles/kusion-linux/bin ./_build/bundles/kusion-ubuntu
+	cp -r ./_build/bundles/kusion-linux/bin ./_build/bundles/kusion-linux
 
 	# Build tgz
-	cd ./_build/bundles/kusion-ubuntu && tar -zcvf ../kusion-ubuntu.tgz  .
-	cd ./_build/bundles && go run ../../scripts/md5file/main.go kusion-ubuntu.tgz > kusion-ubuntu.tgz.md5.txt
-
-build-local-centos-all: build-local-linux  ## Build kusion & kcl tool chain for linux
-	# Install kclvm linux
-	go run ./scripts/install-kclvm \
-		--triple=centos \
-		--mirrors=${KCLVM_URL_BASE_MIRRORS} \
-		--outdir=./_build/bundles/kusion-centos/kclvm
-
-	# Build kcl-go
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
-		go build -o ${PWD}/_build/bundles/kusion-centos/kclvm/bin/kcl-go \
-		./scripts/install-kcl-go
-
-	# Build kcl-openapi
-	cd ./scripts/install-kcl-openapi && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
-		go build -o ${PWD}/_build/bundles/kusion-centos/bin/kcl-openapi
-
-	# chmod +x
-	-chmod +x ./_build/bundles/kusion-linux/bin/kusion
-	-chmod +x ./_build/bundles/kusion-centos/bin/kcl-openapi
-	-chmod +x ./_build/bundles/kusion-centos/kclvm/bin/kcl
-	-chmod +x ./_build/bundles/kusion-centos/kclvm/bin/kclvm
-	-chmod +x ./_build/bundles/kusion-centos/kclvm/bin/kcl-plugin
-	-chmod +x ./_build/bundles/kusion-centos/kclvm/bin/kcl-doc
-	-chmod +x ./_build/bundles/kusion-centos/kclvm/bin/kcl-test
-	-chmod +x ./_build/bundles/kusion-centos/kclvm/bin/kcl-lint
-	-chmod +x ./_build/bundles/kusion-centos/kclvm/bin/kcl-fmt
-	-chmod +x ./_build/bundles/kusion-centos/kclvm/bin/kcl-vet
-	-chmod +x ./_build/bundles/kusion-centos/kclvm/bin/kcl-go
-	-chmod +x ./_build/bundles/kusion-centos/kclvm/bin/kclvm_cli
-	# linux use native clang and need not chmod
-
-	# Copy docs
-	cp -r ./docs ./_build/bundles/kusion-centos/docs
-
-	# Copy README.md
-	cp ./README.md ./_build/bundles/kusion-centos
-
-	# Copy kusion
-	cp -r ./_build/bundles/kusion-linux/bin ./_build/bundles/kusion-centos
-
-	# Build tgz
-	cd ./_build/bundles/kusion-centos && tar -zcvf ../kusion-centos.tgz  .
-	cd ./_build/bundles && go run ../../scripts/md5file/main.go kusion-centos.tgz > kusion-centos.tgz.md5.txt
+	cd ./_build/bundles/kusion-linux && tar -zcvf ../kusion-linux.tgz  .
+	cd ./_build/bundles && go run ../../scripts/md5file/main.go kusion-linux.tgz > kusion-linux.tgz.md5.txt
 
 build-local-windows:  ## Build kusion tool chain for windows
 	# Delete old artifacts
@@ -316,20 +174,9 @@ build-local-windows:  ## Build kusion tool chain for windows
 		-ldflags="-s -w" .
 
 build-local-windows-all: build-local-windows  ## Build kusion & kcl tool chain for windows
-	# Install kclvm windows
-	go run ./scripts/install-kclvm \
-		--triple=windows \
-		--mirrors=${KCLVM_URL_BASE_MIRRORS} \
-		--outdir=./_build/bundles/kusion-windows/kclvm
-
-	# Build kcl-go
-	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 \
-		go build -o ${PWD}/_build/bundles/kusion-windows/kclvm/kcl-go \
-		./scripts/install-kcl-go
-
 	# Build kcl-openapi
 	cd ./scripts/install-kcl-openapi && GOOS=windows GOARCH=amd64 CGO_ENABLED=0 \
-		go build -o ${PWD}/_build/bundles/kusion-windows/kcl-openapi
+		go build -o ${PWD}/_build/bundles/kusion-windows/kcl-openapi.exe
 
 	# Copy docs
 	cp -r ./docs ./_build/bundles/kusion-windows/docs

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -11,6 +11,7 @@ set -o pipefail
 GO111MODULE=on go install github.com/onsi/ginkgo/v2/ginkgo@v2.0.0
 
 # Build kusion binary
+go generate ./pkg/version
 go build -o bin/kusion .
 
 


### PR DESCRIPTION
- there is no distinction between centos and ubuntu for kclvm
- no need to install kcl-go or kclvm once again, cause they are embebed in kclvm-go
- embeded kcl stuff will save in GOBIN
