### PR TITLE
Support hybrid-runtime resources operation like k8s and terraform in one Stack

### DIFF
--- a/pkg/engine/operation/apply.go
+++ b/pkg/engine/operation/apply.go
@@ -9,6 +9,7 @@ import (
 	"kusionstack.io/kusion/pkg/engine/operation/graph"
 	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
 	"kusionstack.io/kusion/pkg/engine/operation/parser"
+	runtimeinit "kusionstack.io/kusion/pkg/engine/runtime/init"
 	"kusionstack.io/kusion/pkg/engine/states"
 	"kusionstack.io/kusion/pkg/log"
 	"kusionstack.io/kusion/pkg/status"
@@ -80,6 +81,14 @@ func (ao *ApplyOperation) Apply(request *ApplyRequest) (rsp *ApplyResponse, st s
 	priorState, resultState := o.InitStates(&request.Request)
 	priorStateResourceIndex := priorState.Resources.Index()
 
+	resources := request.Spec.Resources
+	resources = append(resources, priorState.Resources...)
+	runtimesMap, s := runtimeinit.AppendRuntimes(resources, o.RuntimeMap)
+	if status.IsErr(s) {
+		return nil, s
+	}
+	o.RuntimeMap = runtimesMap
+
 	// 2. build & walk DAG
 	applyGraph, s := NewApplyGraph(request.Spec, priorState)
 	if status.IsErr(s) {
@@ -94,7 +103,7 @@ func (ao *ApplyOperation) Apply(request *ApplyRequest) (rsp *ApplyResponse, st s
 			CtxResourceIndex:        map[string]*models.Resource{},
 			PriorStateResourceIndex: priorStateResourceIndex,
 			StateResourceIndex:      priorStateResourceIndex,
-			Runtime:                 o.Runtime,
+			RuntimeMap:              o.RuntimeMap,
 			Stack:                   o.Stack,
 			MsgCh:                   o.MsgCh,
 			ResultState:             resultState,

--- a/pkg/engine/operation/apply.go
+++ b/pkg/engine/operation/apply.go
@@ -83,7 +83,7 @@ func (ao *ApplyOperation) Apply(request *ApplyRequest) (rsp *ApplyResponse, st s
 
 	resources := request.Spec.Resources
 	resources = append(resources, priorState.Resources...)
-	runtimesMap, s := runtimeinit.AppendRuntimes(resources, o.RuntimeMap)
+	runtimesMap, s := runtimeinit.Runtimes(resources)
 	if status.IsErr(s) {
 		return nil, s
 	}

--- a/pkg/engine/operation/apply_test.go
+++ b/pkg/engine/operation/apply_test.go
@@ -67,7 +67,7 @@ func TestOperation_Apply(t *testing.T) {
 		PriorStateResourceIndex map[string]*models.Resource
 		StateResourceIndex      map[string]*models.Resource
 		Order                   *opsmodels.ChangeOrder
-		Runtime                 runtime.Runtime
+		RuntimeMap              map[models.Type]runtime.Runtime
 		Stack                   *projectstack.Stack
 		MsgCh                   chan opsmodels.Message
 		resultState             *states.State
@@ -80,7 +80,8 @@ func TestOperation_Apply(t *testing.T) {
 	const Jack = "jack"
 	mf := &models.Spec{Resources: []models.Resource{
 		{
-			ID: Jack,
+			ID:   Jack,
+			Type: runtime.Kubernetes,
 			Attributes: map[string]interface{}{
 				"a": "b",
 			},
@@ -99,7 +100,8 @@ func TestOperation_Apply(t *testing.T) {
 		Operator:      "faker",
 		Resources: []models.Resource{
 			{
-				ID: Jack,
+				ID:   Jack,
+				Type: runtime.Kubernetes,
 				Attributes: map[string]interface{}{
 					"a": "b",
 				},
@@ -134,7 +136,7 @@ func TestOperation_Apply(t *testing.T) {
 			fields: fields{
 				OperationType: opsmodels.Apply,
 				StateStorage:  &local.FileSystemState{Path: filepath.Join("test_data", local.KusionState)},
-				Runtime:       &runtime.KubernetesRuntime{},
+				RuntimeMap:    map[models.Type]runtime.Runtime{runtime.Kubernetes: &runtime.KubernetesRuntime{}},
 				MsgCh:         make(chan opsmodels.Message, 5),
 			},
 			args: args{applyRequest: &ApplyRequest{opsmodels.Request{
@@ -158,7 +160,7 @@ func TestOperation_Apply(t *testing.T) {
 				PriorStateResourceIndex: tt.fields.PriorStateResourceIndex,
 				StateResourceIndex:      tt.fields.StateResourceIndex,
 				ChangeOrder:             tt.fields.Order,
-				Runtime:                 tt.fields.Runtime,
+				RuntimeMap:              tt.fields.RuntimeMap,
 				Stack:                   tt.fields.Stack,
 				MsgCh:                   tt.fields.MsgCh,
 				ResultState:             tt.fields.resultState,

--- a/pkg/engine/operation/apply_test.go
+++ b/pkg/engine/operation/apply_test.go
@@ -17,6 +17,7 @@ import (
 	"kusionstack.io/kusion/pkg/engine/operation/graph"
 	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
 	"kusionstack.io/kusion/pkg/engine/runtime"
+	runtimeinit "kusionstack.io/kusion/pkg/engine/runtime/init"
 	"kusionstack.io/kusion/pkg/engine/states"
 	"kusionstack.io/kusion/pkg/engine/states/local"
 	"kusionstack.io/kusion/pkg/projectstack"
@@ -173,6 +174,9 @@ func TestOperation_Apply(t *testing.T) {
 			monkey.Patch((*graph.ResourceNode).Execute, func(rn *graph.ResourceNode, operation *opsmodels.Operation) status.Status {
 				o.ResultState = rs
 				return nil
+			})
+			monkey.Patch(runtimeinit.Runtimes, func(resources models.Resources) (map[models.Type]runtime.Runtime, status.Status) {
+				return map[models.Type]runtime.Runtime{runtime.Kubernetes: &runtime.KubernetesRuntime{}}, nil
 			})
 
 			gotRsp, gotSt := ao.Apply(tt.args.applyRequest)

--- a/pkg/engine/operation/destory.go
+++ b/pkg/engine/operation/destory.go
@@ -67,7 +67,7 @@ func (do *DestroyOperation) Destroy(request *DestroyRequest) (st status.Status) 
 	resources := request.Request.Spec.Resources
 	priorStateResourceIndex := resources.Index()
 
-	runtimesMap, s := runtimeinit.AppendRuntimes(resources, o.RuntimeMap)
+	runtimesMap, s := runtimeinit.Runtimes(resources)
 	if status.IsErr(s) {
 		return s
 	}

--- a/pkg/engine/operation/destory.go
+++ b/pkg/engine/operation/destory.go
@@ -9,6 +9,7 @@ import (
 	"kusionstack.io/kusion/pkg/engine/operation/graph"
 	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
 	"kusionstack.io/kusion/pkg/engine/operation/parser"
+	runtimeinit "kusionstack.io/kusion/pkg/engine/runtime/init"
 	"kusionstack.io/kusion/pkg/log"
 	"kusionstack.io/kusion/pkg/status"
 	"kusionstack.io/kusion/third_party/terraform/dag"
@@ -66,6 +67,12 @@ func (do *DestroyOperation) Destroy(request *DestroyRequest) (st status.Status) 
 	resources := request.Request.Spec.Resources
 	priorStateResourceIndex := resources.Index()
 
+	runtimesMap, s := runtimeinit.AppendRuntimes(resources, o.RuntimeMap)
+	if status.IsErr(s) {
+		return s
+	}
+	o.RuntimeMap = runtimesMap
+
 	// 2. build & walk DAG
 	destroyGraph, s := NewDestroyGraph(resources)
 	if status.IsErr(s) {
@@ -79,7 +86,7 @@ func (do *DestroyOperation) Destroy(request *DestroyRequest) (st status.Status) 
 			CtxResourceIndex:        map[string]*models.Resource{},
 			PriorStateResourceIndex: priorStateResourceIndex,
 			StateResourceIndex:      priorStateResourceIndex,
-			Runtime:                 o.Runtime,
+			RuntimeMap:              o.RuntimeMap,
 			Stack:                   o.Stack,
 			MsgCh:                   o.MsgCh,
 			ResultState:             resultState,

--- a/pkg/engine/operation/destory_test.go
+++ b/pkg/engine/operation/destory_test.go
@@ -42,8 +42,8 @@ func TestOperation_Destroy(t *testing.T) {
 	}
 
 	resourceState := models.Resource{
-		ID: "id1",
-
+		ID:   "id1",
+		Type: runtime.Kubernetes,
 		Attributes: map[string]interface{}{
 			"foo": "bar",
 		},
@@ -54,7 +54,7 @@ func TestOperation_Destroy(t *testing.T) {
 		opsmodels.Operation{
 			OperationType: opsmodels.Destroy,
 			StateStorage:  &local.FileSystemState{Path: filepath.Join("test_data", local.KusionState)},
-			Runtime:       &runtime.KubernetesRuntime{},
+			RuntimeMap:    map[models.Type]runtime.Runtime{runtime.Kubernetes: &runtime.KubernetesRuntime{}},
 		},
 	}
 	r := &DestroyRequest{

--- a/pkg/engine/operation/models/operation_context.go
+++ b/pkg/engine/operation/models/operation_context.go
@@ -38,8 +38,8 @@ type Operation struct {
 	// ChangeOrder is resources' change order during this operation
 	ChangeOrder *ChangeOrder
 
-	// Runtime is the resource infrastructure runtime of this operation
-	Runtime runtime.Runtime
+	// RuntimeMap contains all infrastructure runtimes involved this operation. The key of this map is the Runtime type
+	RuntimeMap map[models.Type]runtime.Runtime
 
 	// Stack contains info about where this command is invoked
 	Stack *projectstack.Stack

--- a/pkg/engine/operation/preview.go
+++ b/pkg/engine/operation/preview.go
@@ -8,6 +8,7 @@ import (
 	"kusionstack.io/kusion/pkg/engine/models"
 	"kusionstack.io/kusion/pkg/engine/operation/graph"
 	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
+	runtimeinit "kusionstack.io/kusion/pkg/engine/runtime/init"
 	"kusionstack.io/kusion/pkg/engine/states"
 	"kusionstack.io/kusion/pkg/log"
 	"kusionstack.io/kusion/pkg/status"
@@ -60,6 +61,15 @@ func (po *PreviewOperation) Preview(request *PreviewRequest) (rsp *PreviewRespon
 	// 1. init & build Indexes
 	priorState, resultState = po.InitStates(&request.Request)
 
+	// Kusion is a multi-runtime system. We initialize runtimes dynamically by resource types
+	resources := request.Spec.Resources
+	resources = append(resources, priorState.Resources...)
+	runtimesMap, s := runtimeinit.AppendRuntimes(resources, o.RuntimeMap)
+	if status.IsErr(s) {
+		return nil, s
+	}
+	o.RuntimeMap = runtimesMap
+
 	switch o.OperationType {
 	case opsmodels.ApplyPreview:
 		priorStateResourceIndex = priorState.Resources.Index()
@@ -85,7 +95,7 @@ func (po *PreviewOperation) Preview(request *PreviewRequest) (rsp *PreviewRespon
 			StateResourceIndex:      priorStateResourceIndex,
 			IgnoreFields:            o.IgnoreFields,
 			ChangeOrder:             o.ChangeOrder,
-			Runtime:                 o.Runtime, // preview need get the latest spec from runtime
+			RuntimeMap:              o.RuntimeMap,
 			Stack:                   o.Stack,
 			ResultState:             resultState,
 			Lock:                    &sync.Mutex{},

--- a/pkg/engine/operation/preview.go
+++ b/pkg/engine/operation/preview.go
@@ -64,7 +64,7 @@ func (po *PreviewOperation) Preview(request *PreviewRequest) (rsp *PreviewRespon
 	// Kusion is a multi-runtime system. We initialize runtimes dynamically by resource types
 	resources := request.Spec.Resources
 	resources = append(resources, priorState.Resources...)
-	runtimesMap, s := runtimeinit.AppendRuntimes(resources, o.RuntimeMap)
+	runtimesMap, s := runtimeinit.Runtimes(resources)
 	if status.IsErr(s) {
 		return nil, s
 	}

--- a/pkg/engine/operation/preview_test.go
+++ b/pkg/engine/operation/preview_test.go
@@ -31,10 +31,12 @@ var (
 	}
 	FakeResourceState = models.Resource{
 		ID:         "fake-id",
+		Type:       runtime.Kubernetes,
 		Attributes: FakeService,
 	}
 	FakeResourceState2 = models.Resource{
 		ID:         "fake-id-2",
+		Type:       runtime.Kubernetes,
 		Attributes: FakeService,
 	}
 )
@@ -84,7 +86,7 @@ func TestOperation_Preview(t *testing.T) {
 		PriorStateResourceIndex map[string]*models.Resource
 		StateResourceIndex      map[string]*models.Resource
 		Order                   *opsmodels.ChangeOrder
-		Runtime                 runtime.Runtime
+		RuntimeMap              map[models.Type]runtime.Runtime
 		MsgCh                   chan opsmodels.Message
 		resultState             *states.State
 		lock                    *sync.Mutex
@@ -116,7 +118,7 @@ func TestOperation_Preview(t *testing.T) {
 			name: "success-when-apply",
 			fields: fields{
 				OperationType: opsmodels.ApplyPreview,
-				Runtime:       &fakePreviewRuntime{},
+				RuntimeMap:    map[models.Type]runtime.Runtime{runtime.Kubernetes: &fakePreviewRuntime{}},
 				StateStorage:  &local.FileSystemState{Path: local.KusionState},
 				Order:         &opsmodels.ChangeOrder{StepKeys: []string{}, ChangeSteps: map[string]*opsmodels.ChangeStep{}},
 			},
@@ -154,7 +156,7 @@ func TestOperation_Preview(t *testing.T) {
 			name: "success-when-destroy",
 			fields: fields{
 				OperationType: opsmodels.DestroyPreview,
-				Runtime:       &fakePreviewRuntime{},
+				RuntimeMap:    map[models.Type]runtime.Runtime{runtime.Kubernetes: &fakePreviewRuntime{}},
 				StateStorage:  &local.FileSystemState{Path: local.KusionState},
 				Order:         &opsmodels.ChangeOrder{},
 			},
@@ -192,7 +194,7 @@ func TestOperation_Preview(t *testing.T) {
 			name: "fail-because-empty-models",
 			fields: fields{
 				OperationType: opsmodels.ApplyPreview,
-				Runtime:       &fakePreviewRuntime{},
+				RuntimeMap:    map[models.Type]runtime.Runtime{runtime.Kubernetes: &fakePreviewRuntime{}},
 				StateStorage:  &local.FileSystemState{Path: local.KusionState},
 				Order:         &opsmodels.ChangeOrder{},
 			},
@@ -210,7 +212,7 @@ func TestOperation_Preview(t *testing.T) {
 			name: "fail-because-nonexistent-id",
 			fields: fields{
 				OperationType: opsmodels.ApplyPreview,
-				Runtime:       &fakePreviewRuntime{},
+				RuntimeMap:    map[models.Type]runtime.Runtime{runtime.Kubernetes: &fakePreviewRuntime{}},
 				StateStorage:  &local.FileSystemState{Path: local.KusionState},
 				Order:         &opsmodels.ChangeOrder{},
 			},
@@ -225,6 +227,7 @@ func TestOperation_Preview(t *testing.T) {
 							Resources: []models.Resource{
 								{
 									ID:         "fake-id",
+									Type:       runtime.Kubernetes,
 									Attributes: FakeService,
 									DependsOn:  []string{"nonexistent-id"},
 								},
@@ -247,7 +250,7 @@ func TestOperation_Preview(t *testing.T) {
 					PriorStateResourceIndex: tt.fields.PriorStateResourceIndex,
 					StateResourceIndex:      tt.fields.StateResourceIndex,
 					ChangeOrder:             tt.fields.Order,
-					Runtime:                 tt.fields.Runtime,
+					RuntimeMap:              tt.fields.RuntimeMap,
 					MsgCh:                   tt.fields.MsgCh,
 					ResultState:             tt.fields.resultState,
 					Lock:                    tt.fields.lock,

--- a/pkg/engine/operation/preview_test.go
+++ b/pkg/engine/operation/preview_test.go
@@ -7,9 +7,12 @@ import (
 	"sync"
 	"testing"
 
+	"bou.ke/monkey"
+
 	"kusionstack.io/kusion/pkg/engine/models"
 	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
 	"kusionstack.io/kusion/pkg/engine/runtime"
+	runtimeinit "kusionstack.io/kusion/pkg/engine/runtime/init"
 	"kusionstack.io/kusion/pkg/engine/states"
 	"kusionstack.io/kusion/pkg/engine/states/local"
 	"kusionstack.io/kusion/pkg/projectstack"
@@ -256,6 +259,10 @@ func TestOperation_Preview(t *testing.T) {
 					Lock:                    tt.fields.lock,
 				},
 			}
+
+			monkey.Patch(runtimeinit.Runtimes, func(resources models.Resources) (map[models.Type]runtime.Runtime, status.Status) {
+				return map[models.Type]runtime.Runtime{runtime.Kubernetes: &fakePreviewRuntime{}}, nil
+			})
 			gotRsp, gotS := o.Preview(tt.args.request)
 			if !reflect.DeepEqual(gotRsp, tt.wantRsp) {
 				t.Errorf("Operation.Preview() gotRsp = %v, want %v", kdump.FormatN(gotRsp), kdump.FormatN(tt.wantRsp))

--- a/pkg/engine/operation/watch.go
+++ b/pkg/engine/operation/watch.go
@@ -37,10 +37,11 @@ func (wo *WatchOperation) Watch(req *WatchRequest) error {
 
 	// init runtimes
 	resources := req.Spec.Resources
-	runtimes, s := runtimeinit.AppendRuntimes(resources, wo.RuntimeMap)
+	runtimes, s := runtimeinit.Runtimes(resources)
 	if status.IsErr(s) {
 		return errors.New(s.Message())
 	}
+	wo.RuntimeMap = runtimes
 
 	// Result channels
 	msgChs := make(map[string][]<-chan k8swatch.Event, len(resources))

--- a/pkg/engine/operation/watch.go
+++ b/pkg/engine/operation/watch.go
@@ -2,6 +2,7 @@ package operation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"kusionstack.io/kusion/pkg/engine/printers"
 	"kusionstack.io/kusion/pkg/engine/printers/k8s"
 	"kusionstack.io/kusion/pkg/engine/runtime"
+	runtimeinit "kusionstack.io/kusion/pkg/engine/runtime/init"
 	"kusionstack.io/kusion/pkg/status"
 	"kusionstack.io/kusion/pkg/util/pretty"
 )
@@ -22,7 +24,7 @@ import (
 var tableGenerator = printers.NewTableGenerator().With(k8s.AddHandlers)
 
 type WatchOperation struct {
-	Runtime runtime.Runtime
+	opsmodels.Operation
 }
 
 type WatchRequest struct {
@@ -32,7 +34,14 @@ type WatchRequest struct {
 func (wo *WatchOperation) Watch(req *WatchRequest) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	// init runtimes
 	resources := req.Spec.Resources
+	runtimes, s := runtimeinit.AppendRuntimes(resources, wo.RuntimeMap)
+	if status.IsErr(s) {
+		return errors.New(s.Message())
+	}
+
 	// Result channels
 	msgChs := make(map[string][]<-chan k8swatch.Event, len(resources))
 	// Keep sorted
@@ -40,8 +49,15 @@ func (wo *WatchOperation) Watch(req *WatchRequest) error {
 	// Collect watchers
 	for i := range resources {
 		res := &resources[i]
+
+		// only support k8s resources
+		t := res.Type
+		if runtime.Kubernetes != t {
+			return fmt.Errorf("WARNING: Watch only support Kubernetes resources for now")
+		}
+
 		// Get watchers
-		resp := wo.Runtime.Watch(ctx, &runtime.WatchRequest{Resource: res})
+		resp := runtimes[t].Watch(ctx, &runtime.WatchRequest{Resource: res})
 		if status.IsErr(resp.Status) {
 			return fmt.Errorf(resp.Status.String())
 		}

--- a/pkg/engine/operation/watch_test.go
+++ b/pkg/engine/operation/watch_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sWatch "k8s.io/apimachinery/pkg/watch"
-
 	"kusionstack.io/kusion/pkg/engine/models"
 	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
 	"kusionstack.io/kusion/pkg/engine/runtime"
@@ -27,12 +26,10 @@ func TestWatchOperation_Watch(t *testing.T) {
 			},
 		},
 	}
-	wo := &WatchOperation{Runtime: fooRuntime}
+	wo := &WatchOperation{opsmodels.Operation{RuntimeMap: map[models.Type]runtime.Runtime{runtime.Kubernetes: fooRuntime}}}
 	err := wo.Watch(req)
 	assert.Nil(t, err)
 }
-
-var fooRuntime = &fooWatchRuntime{}
 
 var barDeployment = map[string]interface{}{
 	"apiVersion": "apps/v1",
@@ -55,6 +52,8 @@ var barDeployment = map[string]interface{}{
 		},
 	},
 }
+
+var fooRuntime = &fooWatchRuntime{}
 
 type fooWatchRuntime struct{}
 

--- a/pkg/engine/operation/watch_test.go
+++ b/pkg/engine/operation/watch_test.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"testing"
 
+	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sWatch "k8s.io/apimachinery/pkg/watch"
+
 	"kusionstack.io/kusion/pkg/engine/models"
 	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
 	"kusionstack.io/kusion/pkg/engine/runtime"
+	runtimeinit "kusionstack.io/kusion/pkg/engine/runtime/init"
+	"kusionstack.io/kusion/pkg/status"
 )
 
 func TestWatchOperation_Watch(t *testing.T) {
@@ -26,6 +30,9 @@ func TestWatchOperation_Watch(t *testing.T) {
 			},
 		},
 	}
+	monkey.Patch(runtimeinit.Runtimes, func(resources models.Resources) (map[models.Type]runtime.Runtime, status.Status) {
+		return map[models.Type]runtime.Runtime{runtime.Kubernetes: fooRuntime}, nil
+	})
 	wo := &WatchOperation{opsmodels.Operation{RuntimeMap: map[models.Type]runtime.Runtime{runtime.Kubernetes: fooRuntime}}}
 	err := wo.Watch(req)
 	assert.Nil(t, err)

--- a/pkg/engine/runtime/init/init.go
+++ b/pkg/engine/runtime/init/init.go
@@ -18,12 +18,10 @@ var SupportRuntimes = map[models.Type]InitFn{
 // InitFn runtime init func
 type InitFn func() (runtime.Runtime, error)
 
-func AppendRuntimes(resources models.Resources, runtimesMap map[models.Type]runtime.Runtime) (map[models.Type]runtime.Runtime, status.Status) {
+func Runtimes(resources models.Resources) (map[models.Type]runtime.Runtime, status.Status) {
+	runtimesMap := map[models.Type]runtime.Runtime{}
 	if resources == nil {
 		return runtimesMap, nil
-	}
-	if runtimesMap == nil {
-		runtimesMap = map[models.Type]runtime.Runtime{}
 	}
 
 	for _, resource := range resources {

--- a/pkg/engine/runtime/init/init.go
+++ b/pkg/engine/runtime/init/init.go
@@ -1,18 +1,48 @@
 package init
 
 import (
+	"fmt"
+	"reflect"
+
 	"kusionstack.io/kusion/pkg/engine/models"
 	"kusionstack.io/kusion/pkg/engine/runtime"
 	"kusionstack.io/kusion/pkg/engine/runtime/terraform"
+	"kusionstack.io/kusion/pkg/status"
 )
 
-func InitRuntime() map[models.Type]InitFn {
-	runtimes := map[models.Type]InitFn{
-		runtime.Kubernetes: runtime.NewKubernetesRuntime,
-		runtime.Terraform:  terraform.NewTerraformRuntime,
-	}
-	return runtimes
+var SupportRuntimes = map[models.Type]InitFn{
+	runtime.Kubernetes: runtime.NewKubernetesRuntime,
+	runtime.Terraform:  terraform.NewTerraformRuntime,
 }
 
-// InitFn init Runtime
+// InitFn runtime init func
 type InitFn func() (runtime.Runtime, error)
+
+func AppendRuntimes(resources models.Resources, runtimesMap map[models.Type]runtime.Runtime) (map[models.Type]runtime.Runtime, status.Status) {
+	if resources == nil {
+		return runtimesMap, nil
+	}
+	if runtimesMap == nil {
+		runtimesMap = map[models.Type]runtime.Runtime{}
+	}
+
+	for _, resource := range resources {
+		rt := resource.Type
+		if rt == "" {
+			return nil, status.NewErrorStatusWithCode(status.IllegalManifest, fmt.Errorf("no resource type in resource: %v", resource.ID))
+		}
+
+		if SupportRuntimes[rt] == nil {
+			return nil, status.NewErrorStatusWithCode(status.IllegalManifest, fmt.Errorf("unknow resource type: %s. Currently supported resource types are: %v",
+				rt, reflect.ValueOf(SupportRuntimes).MapKeys()))
+		} else if runtimesMap[rt] == nil {
+			r, err := SupportRuntimes[rt]()
+			if err != nil {
+				return nil, status.NewErrorStatus(fmt.Errorf("init %s runtime failed", rt))
+			}
+			runtimesMap[rt] = r
+		}
+	}
+
+	return runtimesMap, nil
+}

--- a/pkg/kusionctl/cmd/apply/options_test.go
+++ b/pkg/kusionctl/cmd/apply/options_test.go
@@ -199,7 +199,7 @@ func Test_apply(t *testing.T) {
 		changes := opsmodels.NewChanges(project, stack, order)
 		o := NewApplyOptions()
 		o.DryRun = true
-		err := Apply(o, &fakerRuntime{}, stateStorage, planResources, changes, os.Stdout)
+		err := Apply(o, stateStorage, planResources, changes, os.Stdout)
 		assert.Nil(t, err)
 	})
 	t.Run("apply success", func(t *testing.T) {
@@ -225,7 +225,7 @@ func Test_apply(t *testing.T) {
 		}
 		changes := opsmodels.NewChanges(project, stack, order)
 
-		err := Apply(o, &fakerRuntime{}, stateStorage, planResources, changes, os.Stdout)
+		err := Apply(o, stateStorage, planResources, changes, os.Stdout)
 		assert.Nil(t, err)
 	})
 	t.Run("apply failed", func(t *testing.T) {
@@ -246,7 +246,7 @@ func Test_apply(t *testing.T) {
 		}
 		changes := opsmodels.NewChanges(project, stack, order)
 
-		err := Apply(o, &fakerRuntime{}, stateStorage, planResources, changes, os.Stdout)
+		err := Apply(o, stateStorage, planResources, changes, os.Stdout)
 		assert.NotNil(t, err)
 	})
 }

--- a/pkg/kusionctl/cmd/cmd.go
+++ b/pkg/kusionctl/cmd/cmd.go
@@ -123,7 +123,7 @@ func NewKusionctlCmd(in io.Reader, out, err io.Writer) *cobra.Command {
 			},
 		},
 		{
-			Message: "Runtime Commands:",
+			Message: "RuntimeMap Commands:",
 			Commands: []*cobra.Command{
 				preview.NewCmdPreview(),
 				apply.NewCmdApply(),

--- a/pkg/kusionctl/cmd/destroy/options_test.go
+++ b/pkg/kusionctl/cmd/destroy/options_test.go
@@ -103,7 +103,7 @@ func Test_preview(t *testing.T) {
 
 		o := NewDestroyOptions()
 		stateStorage := &local.FileSystemState{Path: filepath.Join(o.WorkDir, local.KusionState)}
-		_, err := o.preview(&models.Spec{Resources: []models.Resource{sa1}}, project, stack, &fakerRuntime{}, stateStorage)
+		_, err := o.preview(&models.Spec{Resources: []models.Resource{sa1}}, project, stack, stateStorage)
 		assert.Nil(t, err)
 	})
 }
@@ -218,7 +218,7 @@ func Test_destroy(t *testing.T) {
 
 		stateStorage := &local.FileSystemState{Path: filepath.Join(o.WorkDir, local.KusionState)}
 
-		err := o.destroy(planResources, changes, &fakerRuntime{}, stateStorage)
+		err := o.destroy(planResources, changes, stateStorage)
 		assert.Nil(t, err)
 	})
 	t.Run("destroy failed", func(t *testing.T) {
@@ -241,7 +241,7 @@ func Test_destroy(t *testing.T) {
 		changes := opsmodels.NewChanges(project, stack, order)
 		stateStorage := &local.FileSystemState{Path: filepath.Join(o.WorkDir, local.KusionState)}
 
-		err := o.destroy(planResources, changes, &fakerRuntime{}, stateStorage)
+		err := o.destroy(planResources, changes, stateStorage)
 		assert.NotNil(t, err)
 	})
 }

--- a/pkg/kusionctl/cmd/preview/options.go
+++ b/pkg/kusionctl/cmd/preview/options.go
@@ -11,11 +11,8 @@ import (
 	"kusionstack.io/kusion/pkg/engine/models"
 	"kusionstack.io/kusion/pkg/engine/operation"
 	opsmodels "kusionstack.io/kusion/pkg/engine/operation/models"
-	"kusionstack.io/kusion/pkg/engine/runtime"
-	runtimeInit "kusionstack.io/kusion/pkg/engine/runtime/init"
 	"kusionstack.io/kusion/pkg/engine/states"
 	compilecmd "kusionstack.io/kusion/pkg/kusionctl/cmd/compile"
-	"kusionstack.io/kusion/pkg/kusionctl/cmd/util"
 	"kusionstack.io/kusion/pkg/log"
 	"kusionstack.io/kusion/pkg/projectstack"
 	"kusionstack.io/kusion/pkg/status"
@@ -91,18 +88,7 @@ func (o *PreviewOptions) Run() error {
 	}
 
 	// Compute changes for preview
-	runtimes := runtimeInit.InitRuntime()
-	runtimeInitFun, err := util.ValidateResourceType(runtimes, planResources.Resources[0].Type)
-	if err != nil {
-		return err
-	}
-
-	r, err := runtimeInitFun()
-	if err != nil {
-		return err
-	}
-
-	changes, err := Preview(o, r, stateStorage, planResources, project, stack)
+	changes, err := Preview(o, stateStorage, planResources, project, stack)
 	if err != nil {
 		return err
 	}
@@ -155,7 +141,6 @@ func (o *PreviewOptions) Run() error {
 //	}
 func Preview(
 	o *PreviewOptions,
-	runtime runtime.Runtime,
 	storage states.StateStorage,
 	planResources *models.Spec,
 	project *projectstack.Project,
@@ -167,7 +152,6 @@ func Preview(
 	pc := &operation.PreviewOperation{
 		Operation: opsmodels.Operation{
 			OperationType: opsmodels.ApplyPreview,
-			Runtime:       runtime,
 			Stack:         stack,
 			StateStorage:  storage,
 			IgnoreFields:  o.IgnoreFields,

--- a/pkg/kusionctl/cmd/preview/options_test.go
+++ b/pkg/kusionctl/cmd/preview/options_test.go
@@ -52,7 +52,7 @@ func Test_preview(t *testing.T) {
 		mockOperationPreview()
 
 		o := NewPreviewOptions()
-		_, err := Preview(o, &fooRuntime{}, stateStorage, &models.Spec{Resources: []models.Resource{sa1, sa2, sa3}}, project, stack)
+		_, err := Preview(o, stateStorage, &models.Spec{Resources: []models.Resource{sa1, sa2, sa3}}, project, stack)
 		assert.Nil(t, err)
 	})
 }

--- a/pkg/kusionctl/cmd/util/helpers.go
+++ b/pkg/kusionctl/cmd/util/helpers.go
@@ -2,10 +2,6 @@ package util
 
 import (
 	"errors"
-	"fmt"
-
-	"kusionstack.io/kusion/pkg/engine/models"
-	runtimeInit "kusionstack.io/kusion/pkg/engine/runtime/init"
 )
 
 func RecoverErr(err *error) {
@@ -16,7 +12,7 @@ func RecoverErr(err *error) {
 		case error:
 			*err = x
 		default:
-			*err = errors.New("unknow panic")
+			*err = errors.New("unknown panic")
 		}
 	}
 }
@@ -25,16 +21,4 @@ func CheckErr(err error) {
 	if err != nil {
 		panic(err)
 	}
-}
-
-func ValidateResourceType(runtimes map[models.Type]runtimeInit.InitFn, t models.Type) (runtimeInit.InitFn, error) {
-	supportTypes := make([]models.Type, 0, len(runtimes))
-	for k := range runtimes {
-		supportTypes = append(supportTypes, k)
-	}
-	typeFun := runtimes[t]
-	if typeFun == nil {
-		return nil, fmt.Errorf("unknow resource type: %s. Currently supported resource types are: %v", t, supportTypes)
-	}
-	return typeFun, nil
 }


### PR DESCRIPTION
upgrade all operations to support manipulating multi-runtime resources in one Stack. This commit consist of two major changes

1. update the Runtime field in Operation to RuntimeMap to contains multi-runtimes 
2. move Runtime initialization from cmd to engine because we can figure out all Runtime types in one Stack only if merging plan resources and prior resources together

<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y

#218 
<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kusionstack/KCLVM/kclvm-parser 
-->
cmd & engine
#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->
upgrade all operations to support manipulating multi-runtime resources in one Stack. This commit consist of two major changes

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
Support hybrid-runtime resources operation like k8s and terraform in one Stack
```
