### PR TITLE
bugfix: no such file or directory for compile

### DIFF
--- a/pkg/kusionctl/cmd/compile/options.go
+++ b/pkg/kusionctl/cmd/compile/options.go
@@ -93,6 +93,9 @@ func (o *CompileOptions) PreSet(preCheck func(cur string) bool) {
 		curDir, _ = os.Getwd()
 	}
 	if ok := preCheck(curDir); !ok {
+		if o.Output == "" {
+			o.Output = Stdout
+		}
 		return
 	}
 


### PR DESCRIPTION
close: #223

when compile KCL project, will default output to `ci-test/std.golden.yaml` when compile single KCL file, should default output to `stdout`