### PR TITLE
Fix invalide hcl file name

### DIFF
--- a/pkg/engine/runtime/terraform/terraform_runtime.go
+++ b/pkg/engine/runtime/terraform/terraform_runtime.go
@@ -64,7 +64,7 @@ func (t *TerraformRuntime) Apply(ctx context.Context, request *runtime.ApplyRequ
 		return &runtime.ApplyResponse{Resource: nil, Status: status.NewErrorStatus(err)}
 	}
 
-	_, err := os.Stat(filepath.Join(tfCacheDir, tfops.HCLLOCKFILE))
+	_, err := os.Stat(filepath.Join(tfCacheDir, tfops.LockHCLFile))
 	if err != nil {
 		if os.IsNotExist(err) {
 			if err := t.WorkSpace.InitWorkSpace(ctx); err != nil {
@@ -126,7 +126,7 @@ func (t *TerraformRuntime) Read(ctx context.Context, request *runtime.ReadReques
 	if err := t.WorkSpace.WriteHCL(); err != nil {
 		return &runtime.ReadResponse{Resource: nil, Status: status.NewErrorStatus(err)}
 	}
-	_, err := os.Stat(filepath.Join(tfCacheDir, tfops.HCLLOCKFILE))
+	_, err := os.Stat(filepath.Join(tfCacheDir, tfops.LockHCLFile))
 	if err != nil {
 		if os.IsNotExist(err) {
 			if err := t.WorkSpace.InitWorkSpace(ctx); err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug
#### What this PR does / why we need it:
The original hcl lock file name is wrong, and I rename it to the right one

![image](https://user-images.githubusercontent.com/4793557/222324171-9aa7a330-8a87-4e62-aec2-6bca49fa4cca.png)

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
None
```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
