### PR TITLE
fix refreshing tf resources errors in read method

### DIFF
--- a/pkg/engine/runtime/terraform/terraform_runtime.go
+++ b/pkg/engine/runtime/terraform/terraform_runtime.go
@@ -103,16 +103,25 @@ func (t *TerraformRuntime) Apply(ctx context.Context, request *runtime.ApplyRequ
 
 // Read terraform show state
 func (t *TerraformRuntime) Read(ctx context.Context, request *runtime.ReadRequest) *runtime.ReadResponse {
-	priorState := request.PriorResource
+	priorResource := request.PriorResource
 	requestResource := request.PlanResource
 
 	// When the operation is create or update, the requestResource is set to planResource,
 	// when the operation is delete, planResource is nil, the requestResource is set to priorResource,
 	// tf runtime uses requestResource to rebuild tfcache resources.
-	if requestResource == nil {
-		requestResource = request.PriorResource
+	if requestResource == nil && priorResource != nil {
+		// We only need to refresh the tf.state files and return the latest resources state in this method.
+		// Attributes in resources aren't necessary for the command `terraform apply -refresh-only` and will make errors
+		// if fields copied from kusion_state.json but illegal in .tf like the field `id`
+		requestResource = &models.Resource{
+			ID:         priorResource.ID,
+			Type:       priorResource.Type,
+			Attributes: nil,
+			DependsOn:  priorResource.DependsOn,
+			Extensions: priorResource.Extensions,
+		}
 	}
-	if priorState == nil {
+	if priorResource == nil {
 		return &runtime.ReadResponse{Resource: nil, Status: nil}
 	}
 	var tfstate *tfops.TFState
@@ -123,6 +132,7 @@ func (t *TerraformRuntime) Read(ctx context.Context, request *runtime.ReadReques
 	t.WorkSpace.SetStackDir(stackPath)
 	t.WorkSpace.SetCacheDir(tfCacheDir)
 	t.WorkSpace.SetResource(requestResource)
+
 	if err := t.WorkSpace.WriteHCL(); err != nil {
 		return &runtime.ReadResponse{Resource: nil, Status: status.NewErrorStatus(err)}
 	}
@@ -137,8 +147,8 @@ func (t *TerraformRuntime) Read(ctx context.Context, request *runtime.ReadReques
 		}
 	}
 
-	// priorState overwrite tfstate in workspace
-	if err := t.WorkSpace.WriteTFState(priorState); err != nil {
+	// priorResource overwrite tfstate in workspace
+	if err = t.WorkSpace.WriteTFState(priorResource); err != nil {
 		return &runtime.ReadResponse{Resource: nil, Status: status.NewErrorStatus(err)}
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:
we only need to refresh the tf.state files and return the latest resources state in this method.
Attributes in resources aren't necessary for the command `terraform apply -refresh-only` and will make errors if fields copied from kusion_state.json but illegal in .tf like the field `id`
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #264 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
None
```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
