### PR TITLE
bugfix: kusion destrory tf resources requires prior state and plan state

### DIFF
--- a/pkg/engine/operation/destory.go
+++ b/pkg/engine/operation/destory.go
@@ -62,11 +62,10 @@ func (do *DestroyOperation) Destroy(request *DestroyRequest) (st status.Status) 
 	}
 
 	// 1. init & build Indexes
-	_, resultState := o.InitStates(&request.Request)
-	// replace priorState.Resources with models.Resources, so we do Delete in all nodes
-	resources := request.Request.Spec.Resources
-	priorStateResourceIndex := resources.Index()
+	priorState, resultState := o.InitStates(&request.Request)
+	priorStateResourceIndex := priorState.Resources.Index()
 
+	resources := request.Request.Spec.Resources
 	runtimesMap, s := runtimeinit.Runtimes(resources)
 	if status.IsErr(s) {
 		return s

--- a/pkg/engine/operation/graph/resource_node.go
+++ b/pkg/engine/operation/graph/resource_node.go
@@ -61,9 +61,6 @@ func (rn *ResourceNode) Execute(operation *opsmodels.Operation) status.Status {
 
 	// 1. prepare planedState
 	planedState := rn.state
-	if rn.Action == opsmodels.Delete {
-		planedState = nil
-	}
 	// predictableState represents dry-run result
 	predictableState := planedState
 

--- a/pkg/engine/operation/preview_test.go
+++ b/pkg/engine/operation/preview_test.go
@@ -190,7 +190,7 @@ func TestOperation_Preview(t *testing.T) {
 							ID:     "fake-id-2",
 							Action: opsmodels.Delete,
 							From:   &FakeResourceState2,
-							To:     (*models.Resource)(nil),
+							To:     &FakeResourceState2,
 						},
 					},
 				},


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug

#### What this PR does / why we need it:

kusion destroy TF resources, return success, but still there

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/KusionStack/kusion/issues/271

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
NONE
```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
