### PR TITLE
make monitoring output less colourful

### DIFF
--- a/pkg/engine/operation/watch.go
+++ b/pkg/engine/operation/watch.go
@@ -179,7 +179,7 @@ func (wo *WatchOperation) printTables(w *uilive.Writer, ids []string, tables map
 		table, ok := tables[id]
 		if !ok {
 			// Terraform resource, leave a hint
-			_, _ = fmt.Fprintln(w, pretty.LightYellow("! Terraform resources, skip monitoring"))
+			_, _ = fmt.Fprintln(w, "Skip monitoring Terraform resources")
 		} else {
 			// Print table
 			data := table.Print()


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:
Watching TF resources is not supported now. It is kind of our disadvantage, but we will record a promotion demo video recently. So I change the hint color to normal text to make it less attractive.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
none
```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
