### PR TITLE
write tf.json and tf.state with pretty json to make them more user-friendly

### DIFF
--- a/pkg/engine/runtime/terraform/tfops/workspace.go
+++ b/pkg/engine/runtime/terraform/tfops/workspace.go
@@ -17,6 +17,7 @@ import (
 
 	"kusionstack.io/kusion/pkg/engine/models"
 	"kusionstack.io/kusion/pkg/log"
+	jsonutil "kusionstack.io/kusion/pkg/util/json"
 	"kusionstack.io/kusion/pkg/util/kfile"
 )
 
@@ -90,13 +91,9 @@ func (w *WorkSpace) WriteHCL() error {
 			},
 		},
 	}
-	hclMain, err := json.Marshal(m)
-	if err != nil {
-		return fmt.Errorf("marshal hcl main error: %v", err)
-	}
+	hclMain := jsonutil.Marshal2PrettyString(m)
 
-	_, err = w.fs.Stat(w.tfCacheDir)
-
+	_, err := w.fs.Stat(w.tfCacheDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			if err := w.fs.MkdirAll(w.tfCacheDir, os.ModePerm); err != nil {
@@ -106,7 +103,7 @@ func (w *WorkSpace) WriteHCL() error {
 			return err
 		}
 	}
-	err = w.fs.WriteFile(filepath.Join(w.tfCacheDir, MainTFFile), hclMain, 0o600)
+	err = w.fs.WriteFile(filepath.Join(w.tfCacheDir, MainTFFile), []byte(hclMain), 0o600)
 	if err != nil {
 		return fmt.Errorf("write hcl main.tf.json error: %v", err)
 	}
@@ -133,12 +130,9 @@ func (w *WorkSpace) WriteTFState(priorState *models.Resource) error {
 			},
 		},
 	}
-	hclState, err := json.Marshal(m)
-	if err != nil {
-		return fmt.Errorf("marshal hcl state error: %v", err)
-	}
+	hclState := jsonutil.Marshal2PrettyString(m)
 
-	err = w.fs.WriteFile(filepath.Join(w.tfCacheDir, TFStateFile), hclState, os.ModePerm)
+	err := w.fs.WriteFile(filepath.Join(w.tfCacheDir, TFStateFile), []byte(hclState), os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("write hcl error: %v", err)
 	}

--- a/pkg/engine/runtime/terraform/tfops/workspace_test.go
+++ b/pkg/engine/runtime/terraform/tfops/workspace_test.go
@@ -79,7 +79,7 @@ func TestWriteHCL(t *testing.T) {
 				w: NewWorkSpace(fs),
 			},
 			want: want{
-				maintf: "{\"provider\":{\"local\":null},\"resource\":{\"local_file\":{\"kusion_example\":{\"content\":\"kusion\",\"filename\":\"test.txt\"}}},\"terraform\":{\"required_providers\":{\"local\":{\"source\":\"registry.terraform.io/hashicorp/local\",\"version\":\"2.2.3\"}}}}",
+				maintf: "{\n  \"provider\": {\n    \"local\": null\n  },\n  \"resource\": {\n    \"local_file\": {\n      \"kusion_example\": {\n        \"content\": \"kusion\",\n        \"filename\": \"test.txt\"\n      }\n    }\n  },\n  \"terraform\": {\n    \"required_providers\": {\n      \"local\": {\n        \"source\": \"registry.terraform.io/hashicorp/local\",\n        \"version\": \"2.2.3\"\n      }\n    }\n  }\n}",
 			},
 		},
 	}
@@ -118,7 +118,7 @@ func TestWriteTFState(t *testing.T) {
 				w: NewWorkSpace(fs),
 			},
 			want: want{
-				tfstate: "{\"resources\":[{\"instances\":[{\"attributes\":{\"content\":\"kusion\",\"filename\":\"test.txt\"}}],\"mode\":\"managed\",\"name\":\"kusion_example\",\"provider\":\"provider[\\\"registry.terraform.io/hashicorp/local\\\"]\",\"type\":\"local_file\"}],\"version\":4}",
+				tfstate: "{\n  \"resources\": [\n    {\n      \"instances\": [\n        {\n          \"attributes\": {\n            \"content\": \"kusion\",\n            \"filename\": \"test.txt\"\n          }\n        }\n      ],\n      \"mode\": \"managed\",\n      \"name\": \"kusion_example\",\n      \"provider\": \"provider[\\\"registry.terraform.io/hashicorp/local\\\"]\",\n      \"type\": \"local_file\"\n    }\n  ],\n  \"version\": 4\n}",
 			},
 		},
 	}

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -75,7 +75,7 @@ func Marshal2String(v interface{}) string {
 func Marshal2PrettyString(v interface{}) string {
 	r, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
-		return "marshal failed"
+		return "marshal to pretty json failed"
 	}
 
 	return string(r)
@@ -92,7 +92,7 @@ func MustMarshal2String(v interface{}) string {
 // MustMarshal2PrettyString marshal to pretty string and panic on error
 func MustMarshal2PrettyString(v interface{}) string {
 	r, err := json.MarshalIndent(v, "", "  ")
-	util.CheckNotError(err, "json marshal failed")
+	util.CheckNotError(err, "must marshal to pretty json failed")
 
 	return string(r)
 }


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:
write tf.json and tf.state with pretty json to make them more user-friendly
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #282 

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
wirite `main.tf.json` and `terraform.tfstate` with pretty json to make them user friendly
```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
