### PR TITLE
revert an old commit to fix generating illegal tf.json

### DIFF
--- a/pkg/engine/operation/graph/resource_node.go
+++ b/pkg/engine/operation/graph/resource_node.go
@@ -62,6 +62,11 @@ func (rn *ResourceNode) Execute(operation *opsmodels.Operation) status.Status {
 
 	// 1. prepare planedState
 	planedState := rn.state
+	// When a resource is deleted in Spec but exists in PriorState,
+	// this node should be regarded as a deleted node, and rn.state stores the PriorState
+	if rn.Action == opsmodels.Delete {
+		planedState = nil
+	}
 	// predictableState represents dry-run result
 	predictableState := planedState
 

--- a/pkg/engine/operation/preview_test.go
+++ b/pkg/engine/operation/preview_test.go
@@ -190,7 +190,7 @@ func TestOperation_Preview(t *testing.T) {
 							ID:     "fake-id-2",
 							Action: opsmodels.Delete,
 							From:   &FakeResourceState2,
-							To:     &FakeResourceState2,
+							To:     (*models.Resource)(nil),
 						},
 					},
 				},

--- a/pkg/engine/runtime/terraform/terraform_runtime.go
+++ b/pkg/engine/runtime/terraform/terraform_runtime.go
@@ -110,6 +110,7 @@ func (t *TerraformRuntime) Read(ctx context.Context, request *runtime.ReadReques
 	// when the operation is delete, planResource is nil, the requestResource is set to priorResource,
 	// tf runtime uses requestResource to rebuild tfcache resources.
 	if requestResource == nil && priorResource != nil {
+		// requestResource is nil representing that this is a Delete action.
 		// We only need to refresh the tf.state files and return the latest resources state in this method.
 		// Attributes in resources aren't necessary for the command `terraform apply -refresh-only` and will make errors
 		// if fields copied from kusion_state.json but illegal in .tf like the field `id`


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug

#### What this PR does / why we need it:
Fix generating illegal tf.json

When a resource is deleted in Spec but exists in PriorState, this node should be regarded as a deleted node, and rn.state stores the PriorState. So we should set the planedState as nil

#### Fixs: #287 