### PR TITLE
Only destroy resources Kusion already managed

### DIFF
--- a/pkg/engine/models/spec.go
+++ b/pkg/engine/models/spec.go
@@ -5,6 +5,8 @@ type Spec struct {
 	Resources Resources `json:"resources" yaml:"resources"`
 }
 
+// fixme: get `cluster` from compile arguments
+
 // ParseCluster try to parse Cluster from resource extensions.
 // All resources in one compile MUST have the same Cluster and this constraint will be guaranteed by KCL compile logic
 func (s *Spec) ParseCluster() string {

--- a/pkg/engine/operation/destory.go
+++ b/pkg/engine/operation/destory.go
@@ -65,7 +65,8 @@ func (do *DestroyOperation) Destroy(request *DestroyRequest) (st status.Status) 
 	priorState, resultState := o.InitStates(&request.Request)
 	priorStateResourceIndex := priorState.Resources.Index()
 
-	resources := request.Request.Spec.Resources
+	// only destroy resources we have recorded
+	resources := priorState.Resources
 	runtimesMap, s := runtimeinit.Runtimes(resources)
 	if status.IsErr(s) {
 		return s

--- a/pkg/engine/operation/models/operation_context.go
+++ b/pkg/engine/operation/models/operation_context.go
@@ -108,9 +108,7 @@ func (o *Operation) InitStates(request *Request) (*states.State, *states.State) 
 		Project: request.Project.Name,
 		Cluster: request.Cluster,
 	}
-	latestState, err := o.StateStorage.GetLatestState(
-		query,
-	)
+	latestState, err := o.StateStorage.GetLatestState(query)
 	util.CheckNotError(err, fmt.Sprintf("get the latest State failed with query: %v", jsonutil.Marshal2PrettyString(query)))
 	if latestState == nil {
 		log.Infof("can't find states with request: %v", jsonutil.Marshal2PrettyString(request))

--- a/pkg/engine/operation/parser/delete_resource_parser.go
+++ b/pkg/engine/operation/parser/delete_resource_parser.go
@@ -69,7 +69,7 @@ func (d *DeleteResourceParser) Parse(g *dag.AcyclicGraph) (s status.Status) {
 		}
 
 		// compute implicit and explicate dependencies
-		refNodeKeys, s := computeDependencies(resource)
+		refNodeKeys, s := updateDependencies(resource)
 		if status.IsErr(s) {
 			return s
 		}

--- a/pkg/engine/operation/parser/parser.go
+++ b/pkg/engine/operation/parser/parser.go
@@ -15,7 +15,7 @@ type Parser interface {
 	Parse(dag *dag.AcyclicGraph) status.Status
 }
 
-func computeDependencies(resource *models.Resource) ([]string, status.Status) {
+func updateDependencies(resource *models.Resource) ([]string, status.Status) {
 	// handle explicate dependency
 	refNodeKeys := resource.DependsOn
 
@@ -31,6 +31,7 @@ func computeDependencies(resource *models.Resource) ([]string, status.Status) {
 
 	// Deduplicate
 	refNodeKeys = Deduplicate(refNodeKeys)
+	resource.DependsOn = refNodeKeys
 	return refNodeKeys, nil
 }
 

--- a/pkg/engine/operation/parser/spec_parser.go
+++ b/pkg/engine/operation/parser/spec_parser.go
@@ -52,7 +52,7 @@ func (m *SpecParser) Parse(g *dag.AcyclicGraph) (s status.Status) {
 		}
 
 		// compute implicit and explicate dependencies
-		refNodeKeys, s := computeDependencies(resource)
+		refNodeKeys, s := updateDependencies(resource)
 		if status.IsErr(s) {
 			return s
 		}

--- a/pkg/engine/runtime/kubernetes/kubernetes_runtime.go
+++ b/pkg/engine/runtime/kubernetes/kubernetes_runtime.go
@@ -169,7 +169,7 @@ func (k *KubernetesRuntime) Read(ctx context.Context, request *runtime.ReadReque
 	}
 	// Validate
 	if requestResource == nil {
-		return &runtime.ReadResponse{Status: status.NewErrorStatus(errors.New("requestResource is nil"))}
+		return &runtime.ReadResponse{Status: status.NewErrorStatus(errors.New("can not read k8s resource with empty body"))}
 	}
 
 	// Get resource by attribute


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:
Only destroy resources Kusion already managed in kusion destroy

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #299 

#### Special notes for your reviewer:
none
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
Optimize `kusion destroy` behavior. The destroy operation will only delete resources already managed by Kusion
```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
