### PR TITLE
Update: kusion deps: ignore all paths in --ignore option even if they appear in focus paths

### DIFF
--- a/pkg/cmd/deps/options.go
+++ b/pkg/cmd/deps/options.go
@@ -128,6 +128,17 @@ func (o *DepsOptions) Run() (err error) {
 		shouldIgnore := toSet(o.Ignore)
 		focusPaths := toSet(o.Focus)
 
+		// 2.1 If a path in the focusPaths should be ignored, remove it from the focusPaths
+		for f := range shouldIgnore {
+			if focusPaths.contains(f) {
+				focusPaths.remove(f)
+			}
+		}
+
+		if len(focusPaths) == 0 {
+			return nil
+		}
+
 		// 3. Find all the projects under the workdir
 		var projects []*projectstack.Project
 		if projects, err = projectstack.FindAllProjectsFrom(workDir); err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind update

#### What this PR does / why we need it:

Update: kusion deps: ignore all paths in --ignore option even if they appear in focus paths

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

The old behavior of `kusion deps` was: for entrance file list of each stack/project, if they contains the file that should be ignored(passed through `--ignore` option), then that ignored entrance file will not be regarded as that stack/project's upstream dependency.

That behavior was designed to avoid hotspot dependence like `https://github.com/KusionStack/konfig/blob/main/base/pkg/kusion_models/kube/render/render.k` which will involve almost all the frontend/backend files to a stack/project's upstream dependency.

Now there are scenarios that require ignoring paths even if they appear in focus paths.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
