### PR TITLE
add "init templates" cmd, used to list templates in format

### DIFF
--- a/pkg/cmd/init/init.go
+++ b/pkg/cmd/init/init.go
@@ -12,7 +12,7 @@ var (
 	initShort = `Initialize KCL file structure and base codes for a new project`
 
 	initLong = `
-		kusion init command helps you to generate an scaffolding KCL project.
+		kusion init command helps you to generate a scaffolding KCL project.
 		Try "kusion init" to simply get a demo project.`
 
 	initExample = `
@@ -27,6 +27,19 @@ var (
 
 		# Initialize a new KCL project from local directory
 		kusion init /path/to/templates`
+
+	templatesShort = `List Templates used to initialize a new project`
+
+	templatesLong = `
+		kusion init templates command helps you get the templates which are used
+    to generate a scaffolding KCL project.`
+
+	templatesExample = `
+		# Get name and description of internal templates
+		kusion init templates
+
+		# Get templates from specific templates location
+		kusion init templates https://github.com/<user>/<repo> --online=true`
 )
 
 func NewCmdInit() *cobra.Command {
@@ -52,7 +65,7 @@ func NewCmdInit() *cobra.Command {
 	cmd.Flags().BoolVar(
 		&o.Force, "force", false,
 		i18n.T("Forces content to be generated even if it would change existing files"))
-	cmd.Flags().BoolVar(
+	cmd.PersistentFlags().BoolVar(
 		&o.Online, "online", false,
 		i18n.T("Use locally cached templates without making any network requests"))
 	cmd.Flags().BoolVar(
@@ -61,5 +74,36 @@ func NewCmdInit() *cobra.Command {
 	cmd.Flags().StringVar(
 		&o.CustomParamsJSON, "custom-params", "",
 		i18n.T("Custom params in JSON string; if not empty, kusion will skip prompt process and use it as template default value"))
+
+	templatesCmd := newCmdTemplates()
+	cmd.AddCommand(templatesCmd)
+	return cmd
+}
+
+func newCmdTemplates() *cobra.Command {
+	o := NewTemplatesOptions()
+	cmd := &cobra.Command{
+		Use:                   "templates",
+		Short:                 i18n.T(templatesShort),
+		Long:                  templates.LongDesc(i18n.T(templatesLong)),
+		Example:               templates.Examples(i18n.T(templatesExample)),
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			defer util.RecoverErr(&err)
+			online, err := cmd.InheritedFlags().GetBool("online")
+			if err != nil {
+				return err
+			}
+			util.CheckErr(o.Complete(args, online))
+			util.CheckErr(o.Validate())
+			util.CheckErr(o.Run())
+			return
+		},
+	}
+
+	cmd.Flags().StringVarP(
+		&o.Output, "output", "o", "",
+		i18n.T("The output format, only support json if specified; if not specified, print template name and description"))
+
 	return cmd
 }

--- a/pkg/cmd/init/options_test.go
+++ b/pkg/cmd/init/options_test.go
@@ -41,7 +41,17 @@ func TestRun(t *testing.T) {
 		assert.Nil(t, err)
 		err = o.Run()
 		assert.Nil(t, err)
-		os.RemoveAll(o.ProjectName)
+		_ = os.RemoveAll(o.ProjectName)
+	})
+
+	t.Run("init templates from official url", func(t *testing.T) {
+		o := &TemplatesOptions{
+			Output: jsonOutput,
+		}
+		err := o.Complete(nil, true)
+		assert.Nil(t, err)
+		err = o.Run()
+		assert.Nil(t, err)
 	})
 }
 

--- a/pkg/scaffold/templates.go
+++ b/pkg/scaffold/templates.go
@@ -125,8 +125,10 @@ func LoadTemplate(path string) (Template, error) {
 
 // Template represents a project template.
 type Template struct {
-	Dir  string // The directory containing kusion.yaml.
-	Name string // The name of the template.
+	// The directory containing kusion.yaml.
+	Dir string `json:"dir,omitempty" yaml:"dir,omitempty"`
+	// The name of the template.
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 
 	*ProjectTemplate
 }


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?
feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:
list init templates from local or online, support json format. Hence, user can parse the specific elements of the templates.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #265 

#### Special notes for your reviewer:
If the cmd failed, the output is not in json format, even if "--output=json" is specified.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
None
```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
kusion init templates command helps you get the templates which are used to generate a scaffolding KCL project.
Here are the examples:
# Get name and description of internal templates
  kusion init templates
# Get templates from specific templates location, and output in json format
  kusion init templates https://github.com/<user>/<repo> --online=true --output=json
```
