### PR TITLE
support init with specified template 

### DIFF
--- a/pkg/cmd/init/init.go
+++ b/pkg/cmd/init/init.go
@@ -60,6 +60,9 @@ func NewCmdInit() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(
+		&o.TemplateName, "template-name", "",
+		i18n.T("The template name; if not specified, a prompt will request it"))
+	cmd.Flags().StringVar(
 		&o.ProjectName, "project-name", "",
 		i18n.T("The project name; if not specified, a prompt will request it"))
 	cmd.Flags().BoolVar(

--- a/pkg/cmd/init/options.go
+++ b/pkg/cmd/init/options.go
@@ -18,12 +18,13 @@ import (
 const jsonOutput = "json"
 
 type InitOptions struct {
-	TemplateNameOrURL string
-	Online            bool
-	ProjectName       string
-	Force             bool
-	Yes               bool
-	CustomParamsJSON  string
+	TemplateRepoPath string
+	TemplateName     string
+	Online           bool
+	ProjectName      string
+	Force            bool
+	Yes              bool
+	CustomParamsJSON string
 }
 
 func NewInitOptions() *InitOptions {
@@ -32,31 +33,30 @@ func NewInitOptions() *InitOptions {
 
 func (o *InitOptions) Complete(args []string) error {
 	if o.Online { // use online templates, official link or user-specified link
-		o.TemplateNameOrURL = getURL(args)
+		o.TemplateRepoPath = templateRepoPathFromURL(args)
 	} else { // use offline templates, internal templates or user-specified local dir
-		path, err := getPath(args)
+		path, err := templateRepoPathFromLocal(args)
 		if err != nil {
 			return err
 		}
-		o.TemplateNameOrURL = path
+		o.TemplateRepoPath = path
 	}
 	return nil
 }
 
 func (o *InitOptions) Validate() error {
-	if o.Online {
-		return nil
-	}
-	// offline mode may need to generate templates
-	if err := validatePath(o.TemplateNameOrURL); err != nil {
-		return err
+	if !o.Online {
+		// offline mode may need to generate templates
+		if err := validateLocalTemplateRepoPath(o.TemplateRepoPath); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
 func (o *InitOptions) Run() error {
 	// Retrieve the template repo.
-	repo, err := retrieveTemplateRepo(o.TemplateNameOrURL, o.Online)
+	repo, err := retrieveTemplateRepo(o.TemplateRepoPath, o.Online)
 	if err != nil {
 		return err
 	}
@@ -70,8 +70,23 @@ func (o *InitOptions) Run() error {
 
 	// Choose template
 	var template scaffold.Template
-	if template, err = chooseTemplate(templates); err != nil {
-		return err
+	if o.TemplateName == "" {
+		// if template name is not specified, choose template by prompt
+		if template, err = chooseTemplate(templates); err != nil {
+			return err
+		}
+	} else {
+		// if template name is specified, find template from repo data
+		var templateExist bool
+		for _, t := range templates {
+			t.Name = o.TemplateName
+			templateExist = true
+			template = t
+			break
+		}
+		if !templateExist {
+			return fmt.Errorf("template %s does not exist", o.TemplateName)
+		}
 	}
 
 	// Parse customParams if not empty
@@ -182,10 +197,9 @@ func (o *InitOptions) Run() error {
 }
 
 type TemplatesOptions struct {
-	Online bool
-	URL    string
-	Path   string
-	Output string
+	TemplateRepoPath string
+	Online           bool
+	Output           string
 }
 
 func NewTemplatesOptions() *TemplatesOptions {
@@ -195,12 +209,12 @@ func NewTemplatesOptions() *TemplatesOptions {
 func (o *TemplatesOptions) Complete(args []string, online bool) error {
 	o.Online = online
 	if o.Online {
-		o.URL = getURL(args)
+		o.TemplateRepoPath = templateRepoPathFromURL(args)
 	} else {
-		if path, err := getPath(args); err != nil {
+		if path, err := templateRepoPathFromLocal(args); err != nil {
 			return err
 		} else {
-			o.Path = path
+			o.TemplateRepoPath = path
 		}
 	}
 	return nil
@@ -211,7 +225,7 @@ func (o *TemplatesOptions) Validate() error {
 		return errors.New("invalid output type, supported types: json")
 	}
 	if !o.Online {
-		if err := validatePath(o.Path); err != nil {
+		if err := validateLocalTemplateRepoPath(o.TemplateRepoPath); err != nil {
 			return err
 		}
 	}
@@ -219,14 +233,8 @@ func (o *TemplatesOptions) Validate() error {
 }
 
 func (o *TemplatesOptions) Run() error {
-	var templateName string
-	if o.Online {
-		templateName = o.URL
-	} else {
-		templateName = o.Path
-	}
 	// retrieve template repo
-	repo, err := retrieveTemplateRepo(templateName, o.Online)
+	repo, err := retrieveTemplateRepo(o.TemplateRepoPath, o.Online)
 	if err != nil {
 		return err
 	}
@@ -247,8 +255,8 @@ func (o *TemplatesOptions) Run() error {
 	return nil
 }
 
-// getURL parses url from args, called when --online is true.
-func getURL(args []string) string {
+// templateRepoPathFromURL parses url from args, called when --online is true.
+func templateRepoPathFromURL(args []string) string {
 	if len(args) > 0 {
 		// user-specified link
 		return args[0]
@@ -256,9 +264,9 @@ func getURL(args []string) string {
 	return "" // use official link
 }
 
-// getPath parses path from args, if not specified, use default InternalTemplateDir,
+// templateRepoPathFromLocal parses path from args, if not specified, use default InternalTemplateDir,
 // called when --online is false.
-func getPath(args []string) (string, error) {
+func templateRepoPathFromLocal(args []string) (string, error) {
 	if len(args) > 0 {
 		// user-specified local dir
 		return args[0], nil
@@ -272,8 +280,8 @@ func getPath(args []string) (string, error) {
 	}
 }
 
-// validatePath checks the path is valid or not.
-func validatePath(path string) error {
+// validateLocalTemplateRepoPath checks the path is valid or not.
+func validateLocalTemplateRepoPath(path string) error {
 	// offline mode may need to generate templates
 	internalTemplateDir, err := scaffold.GetTemplateDir(scaffold.InternalTemplateDir)
 	if err != nil {
@@ -289,8 +297,8 @@ func validatePath(path string) error {
 }
 
 // retrieveTemplateRepo gets template repos from online or local, with specified url or path.
-func retrieveTemplateRepo(templateName string, online bool) (scaffold.TemplateRepository, error) {
-	return scaffold.RetrieveTemplates(templateName, online)
+func retrieveTemplateRepo(templateRepoPath string, online bool) (scaffold.TemplateRepository, error) {
+	return scaffold.RetrieveTemplates(templateRepoPath, online)
 }
 
 // deleteTemplateRepo is used to delete the files of the template repos, log warn if failed.

--- a/pkg/cmd/init/options.go
+++ b/pkg/cmd/init/options.go
@@ -33,9 +33,9 @@ func NewInitOptions() *InitOptions {
 
 func (o *InitOptions) Complete(args []string) error {
 	if o.Online { // use online templates, official link or user-specified link
-		o.TemplateRepoPath = templateRepoPathFromURL(args)
+		o.TemplateRepoPath = onlineTemplateRepoPath(args)
 	} else { // use offline templates, internal templates or user-specified local dir
-		path, err := templateRepoPathFromLocal(args)
+		path, err := localTemplateRepoPath(args)
 		if err != nil {
 			return err
 		}
@@ -45,11 +45,12 @@ func (o *InitOptions) Complete(args []string) error {
 }
 
 func (o *InitOptions) Validate() error {
-	if !o.Online {
-		// offline mode may need to generate templates
-		if err := validateLocalTemplateRepoPath(o.TemplateRepoPath); err != nil {
-			return err
-		}
+	if o.Online {
+		return nil
+	}
+	// offline mode may need to generate templates
+	if err := validateLocalTemplateRepoPath(o.TemplateRepoPath); err != nil {
+		return err
 	}
 	return nil
 }
@@ -210,9 +211,9 @@ func NewTemplatesOptions() *TemplatesOptions {
 func (o *TemplatesOptions) Complete(args []string, online bool) error {
 	o.Online = online
 	if o.Online {
-		o.TemplateRepoPath = templateRepoPathFromURL(args)
+		o.TemplateRepoPath = onlineTemplateRepoPath(args)
 	} else {
-		if path, err := templateRepoPathFromLocal(args); err != nil {
+		if path, err := localTemplateRepoPath(args); err != nil {
 			return err
 		} else {
 			o.TemplateRepoPath = path
@@ -256,8 +257,8 @@ func (o *TemplatesOptions) Run() error {
 	return nil
 }
 
-// templateRepoPathFromURL parses url from args, called when --online is true.
-func templateRepoPathFromURL(args []string) string {
+// onlineTemplateRepoPath parses url from args, called when --online is true.
+func onlineTemplateRepoPath(args []string) string {
 	if len(args) > 0 {
 		// user-specified link
 		return args[0]
@@ -265,9 +266,9 @@ func templateRepoPathFromURL(args []string) string {
 	return "" // use official link
 }
 
-// templateRepoPathFromLocal parses path from args, if not specified, use default InternalTemplateDir,
+// localTemplateRepoPath parses path from args, if not specified, use default InternalTemplateDir,
 // called when --online is false.
-func templateRepoPathFromLocal(args []string) (string, error) {
+func localTemplateRepoPath(args []string) (string, error) {
 	if len(args) > 0 {
 		// user-specified local dir
 		return args[0], nil

--- a/pkg/cmd/init/options.go
+++ b/pkg/cmd/init/options.go
@@ -79,10 +79,11 @@ func (o *InitOptions) Run() error {
 		// if template name is specified, find template from repo data
 		var templateExist bool
 		for _, t := range templates {
-			t.Name = o.TemplateName
-			templateExist = true
-			template = t
-			break
+			if t.Name == o.TemplateName {
+				templateExist = true
+				template = t
+				break
+			}
 		}
 		if !templateExist {
 			return fmt.Errorf("template %s does not exist", o.TemplateName)


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?
feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:
support specifying template when kusion init. By using flag --template-name, you can specify the template you want to use, prompt will not exist.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #265 

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
None
```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
