### PR TITLE
support kusion preview --ouput json

### DIFF
--- a/pkg/cmd/preview/options.go
+++ b/pkg/cmd/preview/options.go
@@ -94,11 +94,9 @@ func (o *PreviewOptions) Run() error {
 	}
 
 	// return immediately if no resource found in stack
+	// todo: if there is no resource, should still do diff job; for now, if output is json format, there is no hint
 	if sp == nil || len(sp.Resources) == 0 {
-		if o.Output == jsonOutput {
-			emptyChanges, _ := json.Marshal(&opsmodels.Changes{})
-			fmt.Println(string(emptyChanges))
-		} else {
+		if o.Output != jsonOutput {
 			fmt.Println(pretty.GreenBold("\nNo resource found in this stack."))
 		}
 		return nil

--- a/pkg/cmd/preview/options_test.go
+++ b/pkg/cmd/preview/options_test.go
@@ -103,6 +103,20 @@ func TestPreviewOptions_Run(t *testing.T) {
 		err := o.Run()
 		assert.Nil(t, err)
 	})
+
+	t.Run("json output is true", func(t *testing.T) {
+		defer monkey.UnpatchAll()
+		mockDetectProjectAndStack()
+		mockGenerateSpec()
+		mockNewKubernetesRuntime()
+		mockOperationPreview()
+		mockPromptDetail("")
+
+		o := NewPreviewOptions()
+		o.Output = jsonOutput
+		err := o.Run()
+		assert.Nil(t, err)
+	})
 }
 
 type fooRuntime struct{}

--- a/pkg/cmd/preview/preview.go
+++ b/pkg/cmd/preview/preview.go
@@ -66,4 +66,6 @@ func (o *PreviewOptions) AddPreviewFlags(cmd *cobra.Command) {
 		i18n.T("no-style sets to RawOutput mode and disables all of styling"))
 	cmd.Flags().StringSliceVarP(&o.IgnoreFields, "ignore-fields", "", nil,
 		i18n.T("Ignore differences of target fields"))
+	cmd.Flags().StringVarP(&o.Output, "output", "o", "",
+		i18n.T("Specify the output format"))
 }

--- a/pkg/cmd/spec/generator.go
+++ b/pkg/cmd/spec/generator.go
@@ -14,9 +14,10 @@ import (
 
 func GenerateSpecWithSpinner(o *generator.Options, project *projectstack.Project, stack *projectstack.Stack) (*models.Spec, error) {
 	var sp *pterm.SpinnerPrinter
-	if o.NoStyle {
+	if !o.NoPrompt && o.NoStyle {
 		fmt.Printf("Generating Spec in the Stack %s...\n", stack.Name)
-	} else {
+	}
+	if !o.NoPrompt && !o.NoStyle {
 		sp = &pretty.SpinnerT
 		sp, _ = sp.Start(fmt.Sprintf("Generating Spec in the Stack %s...", stack.Name))
 	}
@@ -41,16 +42,18 @@ func GenerateSpecWithSpinner(o *generator.Options, project *projectstack.Project
 
 	spec, err := g.GenerateSpec(o, stack)
 	if err != nil {
-		if sp != nil {
+		if !o.NoPrompt && sp != nil {
 			sp.Fail()
 		}
 		return nil, err
 	}
 
-	if sp != nil {
+	if !o.NoPrompt && sp != nil {
 		sp.Success()
 	}
-	fmt.Println()
+	if !o.NoPrompt {
+		fmt.Println()
+	}
 
 	return spec, nil
 }

--- a/pkg/engine/operation/models/action.go
+++ b/pkg/engine/operation/models/action.go
@@ -1,6 +1,10 @@
 package models
 
-import "kusionstack.io/kusion/pkg/util/pretty"
+import (
+	"encoding/json"
+
+	"kusionstack.io/kusion/pkg/util/pretty"
+)
 
 // ActionType represents the kind of operation performed by a plan.  It evaluates to its string label.
 type ActionType int64
@@ -22,6 +26,10 @@ func (t ActionType) String() string {
 		"Update",
 		"Delete",
 	}[t]
+}
+
+func (t ActionType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.String())
 }
 
 func (t ActionType) Ing() string {

--- a/pkg/engine/operation/models/change.go
+++ b/pkg/engine/operation/models/change.go
@@ -17,10 +17,14 @@ import (
 )
 
 type ChangeStep struct {
-	ID     string      // the resource id
-	Action ActionType  // the operation performed by this step.
-	From   interface{} // old data
-	To     interface{} // new data
+	// the resource id
+	ID string `json:"id,omitempty" yaml:"id,omitempty"`
+	// the operation performed by this step
+	Action ActionType `json:"action,omitempty" yaml:"action,omitempty"`
+	// old data
+	From interface{} `json:"from,omitempty" yaml:"from,omitempty"`
+	// new data
+	To interface{} `json:"to,omitempty" yaml:"to,omitempty"`
 }
 
 // Diff compares objects(from and to) which stores in ChangeStep,
@@ -78,14 +82,15 @@ var (
 )
 
 type Changes struct {
-	*ChangeOrder
+	*ChangeOrder `json:",inline" yaml:",inline"`
+
 	project *projectstack.Project // the project of current changes
 	stack   *projectstack.Stack   // the stack of current changes
 }
 
 type ChangeOrder struct {
-	StepKeys    []string
-	ChangeSteps map[string]*ChangeStep
+	StepKeys    []string               `json:"stepKeys,omitempty" yaml:"stepKeys,omitempty"`
+	ChangeSteps map[string]*ChangeStep `json:"changeSteps,omitempty" yaml:"changeSteps,omitempty"`
 }
 
 func NewChanges(p *projectstack.Project, s *projectstack.Stack, order *ChangeOrder) *Changes {

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -39,6 +39,9 @@ type Options struct {
 	// OverrideAST is the kclvm option. It is not appropriate to put it here
 	OverrideAST bool
 
-	// NoStyle represent whether turn on the spinner output style
+	// NoStyle represents whether to turn on the spinner output style
 	NoStyle bool
+
+	// NoPrompt represents whether to print prompt or not
+	NoPrompt bool
 }


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?
feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:
when using cmd kusion preview, there is no way to get the pure preview result, cause there is prompt. Support --output json to print the preview result without any unnecessary prompt when succeeded.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #265 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
the output is json marshal of struct pkg/engine/operation/models.Changes
```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
