### PR TITLE
feat: refine no-style and remove no-prompt command option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -98,6 +98,7 @@ require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
 	github.com/a8m/envsubst v1.3.0 // indirect
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/acomagu/bufpipe v1.0.4 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
 	github.com/agext/levenshtein v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -460,8 +460,6 @@ github.com/gookit/color v1.4.2/go.mod h1:fqRyamkC1W8uxl+lxCQxOT09l/vYfZ+QeiX3rKQ
 github.com/gookit/color v1.5.0/go.mod h1:43aQb+Zerm/BWh2GnrgOQm7ffz7tvQXEKV6BFMl7wAo=
 github.com/gookit/color v1.5.3 h1:twfIhZs4QLCtimkP7MOxlF3A0U/5cDPseRT9M/+2SCE=
 github.com/gookit/color v1.5.3/go.mod h1:NUzwzeehUfl7GIb36pqId+UGmRfQcU/WiiyTTeNjHtE=
-github.com/gookit/goutil v0.6.0 h1:uGne/hUNe2xiJZB77QkeIsKsdPRaPyXFv9mUdDqq/Bw=
-github.com/gookit/goutil v0.6.0/go.mod h1:DI6e4Waos7Yzjhoz75YFMpGl08m92cxNu0Tep36D/d0=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,8 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/a8m/envsubst v1.3.0 h1:GmXKmVssap0YtlU3E230W98RWtWCyIZzjtf1apWWyAg=
 github.com/a8m/envsubst v1.3.0/go.mod h1:MVUTQNGQ3tsjOOtKCNd+fl8RzhsXcDvvAEzkhGtlsbY=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/acomagu/bufpipe v1.0.4 h1:e3H4WUzM3npvo5uv95QuJM3cQspFNtFBzvJ2oNjKIDQ=
 github.com/acomagu/bufpipe v1.0.4/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=

--- a/pkg/cmd/apply/options.go
+++ b/pkg/cmd/apply/options.go
@@ -57,7 +57,7 @@ func (o *ApplyOptions) Run() error {
 	// Set no style
 	if o.NoStyle {
 		pterm.DisableStyling()
-		pterm.EnableColor()
+		pterm.DisableColor()
 	}
 
 	// Parse project and stack of work directory

--- a/pkg/cmd/compile/compile.go
+++ b/pkg/cmd/compile/compile.go
@@ -63,6 +63,8 @@ func NewCmdCompile() *cobra.Command {
 		i18n.T("Disable dumping None values"))
 	cmd.Flags().BoolVarP(&o.OverrideAST, "override-AST", "a", false,
 		i18n.T("Specify the override option"))
+	cmd.Flags().BoolVarP(&o.NoStyle, "no-style", "s", false,
+		i18n.T("Disable the output style and color"))
 
 	return cmd
 }

--- a/pkg/cmd/compile/options.go
+++ b/pkg/cmd/compile/options.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/pterm/pterm"
 	yamlv2 "gopkg.in/yaml.v2"
 
 	"kusionstack.io/kusion/pkg/cmd/spec"
@@ -26,6 +27,7 @@ type CompileFlags struct {
 	Overrides   []string
 	DisableNone bool
 	OverrideAST bool
+	NoStyle     bool
 }
 
 const Stdout = "stdout"
@@ -60,6 +62,12 @@ func (o *CompileOptions) Validate() error {
 }
 
 func (o *CompileOptions) Run() error {
+	// Set no style
+	if o.NoStyle {
+		pterm.DisableStyling()
+		pterm.DisableColor()
+	}
+
 	// Parse project and stack of work directory
 	project, stack, err := projectstack.DetectProjectAndStack(o.WorkDir)
 	if err != nil {
@@ -74,6 +82,7 @@ func (o *CompileOptions) Run() error {
 		Overrides:   o.Overrides,
 		DisableNone: o.DisableNone,
 		OverrideAST: o.OverrideAST,
+		NoStyle:     o.NoStyle,
 	}, project, stack)
 	if err != nil {
 		// only print err in the check command

--- a/pkg/cmd/compile/options_test.go
+++ b/pkg/cmd/compile/options_test.go
@@ -1,9 +1,39 @@
 package compile
 
 import (
+	"io/fs"
+	"os"
 	"testing"
 
+	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
+	"kusionstack.io/kusion/pkg/cmd/spec"
+	"kusionstack.io/kusion/pkg/engine"
+	"kusionstack.io/kusion/pkg/engine/models"
+	"kusionstack.io/kusion/pkg/generator"
+	"kusionstack.io/kusion/pkg/projectstack"
+)
+
+var (
+	apiVersion = "v1"
+	kind       = "ServiceAccount"
+	namespace  = "test-ns"
+
+	project = &projectstack.Project{
+		ProjectConfiguration: projectstack.ProjectConfiguration{
+			Name:   "testdata",
+			Tenant: "admin",
+		},
+	}
+	stack = &projectstack.Stack{
+		StackConfiguration: projectstack.StackConfiguration{
+			Name: "dev",
+		},
+	}
+
+	sa1 = newSA("sa1")
+	sa2 = newSA("sa2")
+	sa3 = newSA("sa3")
 )
 
 func TestCompileOptions_preSet(t *testing.T) {
@@ -51,4 +81,57 @@ func TestCompileOptions_preSet(t *testing.T) {
 			assert.Equal(t, tt.want, o)
 		})
 	}
+}
+
+func TestCompileOptions_Run(t *testing.T) {
+	defer func() {
+		os.Remove("kusion_state.json")
+	}()
+
+	t.Run("no style is true", func(t *testing.T) {
+		defer monkey.UnpatchAll()
+		mockDetectProjectAndStack()
+		mockGenerateSpec()
+		mockWriteFile()
+
+		o := NewCompileOptions()
+		o.NoStyle = true
+		err := o.Run()
+		assert.Nil(t, err)
+	})
+}
+
+func newSA(name string) models.Resource {
+	return models.Resource{
+		ID:   engine.BuildID(apiVersion, kind, namespace, name),
+		Type: "Kubernetes",
+		Attributes: map[string]interface{}{
+			"apiVersion": apiVersion,
+			"kind":       kind,
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+		},
+	}
+}
+
+func mockDetectProjectAndStack() {
+	monkey.Patch(projectstack.DetectProjectAndStack, func(stackDir string) (*projectstack.Project, *projectstack.Stack, error) {
+		project.Path = stackDir
+		stack.Path = stackDir
+		return project, stack, nil
+	})
+}
+
+func mockGenerateSpec() {
+	monkey.Patch(spec.GenerateSpecWithSpinner, func(o *generator.Options, project *projectstack.Project, stack *projectstack.Stack) (*models.Spec, error) {
+		return &models.Spec{Resources: []models.Resource{sa1, sa2, sa3}}, nil
+	})
+}
+
+func mockWriteFile() {
+	monkey.Patch(os.WriteFile, func(name string, data []byte, perm fs.FileMode) error {
+		return nil
+	})
 }

--- a/pkg/cmd/preview/options.go
+++ b/pkg/cmd/preview/options.go
@@ -64,7 +64,7 @@ func (o *PreviewOptions) Run() error {
 	// Set no style
 	if o.NoStyle {
 		pterm.DisableStyling()
-		pterm.EnableColor()
+		pterm.DisableColor()
 	}
 	if o.Output == jsonOutput {
 		pterm.DisableStyling()
@@ -86,8 +86,7 @@ func (o *PreviewOptions) Run() error {
 		Overrides:   o.Overrides,
 		DisableNone: o.DisableNone,
 		OverrideAST: o.OverrideAST,
-		NoStyle:     o.NoStyle,
-		NoPrompt:    o.Output == jsonOutput,
+		NoStyle:     o.NoStyle || o.Output == jsonOutput,
 	}, project, stack)
 	if err != nil {
 		return err

--- a/pkg/cmd/preview/options_test.go
+++ b/pkg/cmd/preview/options_test.go
@@ -117,6 +117,20 @@ func TestPreviewOptions_Run(t *testing.T) {
 		err := o.Run()
 		assert.Nil(t, err)
 	})
+
+	t.Run("no style is true", func(t *testing.T) {
+		defer monkey.UnpatchAll()
+		mockDetectProjectAndStack()
+		mockGenerateSpec()
+		mockNewKubernetesRuntime()
+		mockOperationPreview()
+		mockPromptDetail("")
+
+		o := NewPreviewOptions()
+		o.NoStyle = true
+		err := o.Run()
+		assert.Nil(t, err)
+	})
 }
 
 type fooRuntime struct{}

--- a/pkg/cmd/spec/generator.go
+++ b/pkg/cmd/spec/generator.go
@@ -3,7 +3,9 @@ package spec
 import (
 	"fmt"
 
+	"github.com/acarl005/stripansi"
 	"github.com/pterm/pterm"
+	"sigs.k8s.io/kustomize/kyaml/errors"
 
 	"kusionstack.io/kusion/pkg/engine/models"
 	"kusionstack.io/kusion/pkg/generator"
@@ -14,10 +16,9 @@ import (
 
 func GenerateSpecWithSpinner(o *generator.Options, project *projectstack.Project, stack *projectstack.Stack) (*models.Spec, error) {
 	var sp *pterm.SpinnerPrinter
-	if !o.NoPrompt && o.NoStyle {
+	if o.NoStyle {
 		fmt.Printf("Generating Spec in the Stack %s...\n", stack.Name)
-	}
-	if !o.NoPrompt && !o.NoStyle {
+	} else {
 		sp = &pretty.SpinnerT
 		sp, _ = sp.Start(fmt.Sprintf("Generating Spec in the Stack %s...", stack.Name))
 	}
@@ -42,16 +43,21 @@ func GenerateSpecWithSpinner(o *generator.Options, project *projectstack.Project
 
 	spec, err := g.GenerateSpec(o, stack)
 	if err != nil {
-		if !o.NoPrompt && sp != nil {
+		if !o.NoStyle && sp != nil {
 			sp.Fail()
 		}
+
+		if o.NoStyle {
+			return nil, errors.Wrap(stripansi.Strip(err.Error()))
+		}
+
 		return nil, err
 	}
 
-	if !o.NoPrompt && sp != nil {
+	if !o.NoStyle && sp != nil {
 		sp.Success()
 	}
-	if !o.NoPrompt {
+	if !o.NoStyle {
 		fmt.Println()
 	}
 

--- a/pkg/cmd/spec/generator.go
+++ b/pkg/cmd/spec/generator.go
@@ -1,11 +1,11 @@
 package spec
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/acarl005/stripansi"
 	"github.com/pterm/pterm"
-	"sigs.k8s.io/kustomize/kyaml/errors"
 
 	"kusionstack.io/kusion/pkg/engine/models"
 	"kusionstack.io/kusion/pkg/generator"
@@ -47,8 +47,10 @@ func GenerateSpecWithSpinner(o *generator.Options, project *projectstack.Project
 			sp.Fail()
 		}
 
+		// TODO: we will replace this implementation with KCL no-style flag
+		// when it is supported
 		if o.NoStyle {
-			return nil, errors.Wrap(stripansi.Strip(err.Error()))
+			return nil, errors.New(stripansi.Strip(err.Error()))
 		}
 
 		return nil, err

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -41,7 +41,4 @@ type Options struct {
 
 	// NoStyle represents whether to turn on the spinner output style
 	NoStyle bool
-
-	// NoPrompt represents whether to print prompt or not
-	NoPrompt bool
 }


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

/kind feature

#### What this PR does / why we need it:

This PR refines "no-style" command line option. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #366 

#### Special notes for your reviewer:

This PR removes "no-prompt" command line option. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
Add "no-style" option for kusion compile for better third-party integration while remove the "no-prompt" option. 
```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
