### PR TITLE
ci: add ci checks such as commit lint, pull request title lint

### DIFF
--- a/.github/workflows/constraint.yaml
+++ b/.github/workflows/constraint.yaml
@@ -1,0 +1,41 @@
+# Reference from:
+# https://github.com/c-bata/go-prompt/blob/master/.github/workflows/test.yml
+name: Constraints
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+jobs:
+  # Lints Pull Request commits with commitlint.
+  #
+  # Rules can be referenced: 
+  # https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional
+  CommitLint:
+    name: Commit Lint
+    runs-on: ubuntu-latest
+    if: contains(fromJSON('["pull_request"]'), github.event_name)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v5
+
+  # Lints Pull Request title, because the title will be used as the
+  # commit message in branch main.
+  #
+  # Configuration detail can be referenced:
+  # https://github.com/marketplace/actions/pull-request-title-rules
+  PullRequestTitleLint:
+    name: Pull Request Title Lint
+    runs-on: ubuntu-latest
+    if: contains(fromJSON('["pull_request"]'), github.event_name)
+    steps:
+      - uses: deepakputhraya/action-pr-title@master
+        with:
+          allowed_prefixes: 'build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test' # title should start with the given prefix
+          disallowed_prefixes: 'WIP,[WIP]' # title should not start with the given prefix
+          prefix_case_sensitive: false # title prefix are case insensitive
+          min_length: 5 # Min length of the title
+          max_length: 80 # Max length of the title
+          github_token: ${{ github.token }} # Default: ${{ github.token }}
+

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,12 +33,13 @@ jobs:
         uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: coverage.out
-  Lint:
-    name: Lint checks
+
+  GolangLint:
+    name: Golang Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Go 1.19
@@ -50,3 +51,4 @@ jobs:
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.52.2
+

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,7 +48,7 @@ linters:
 linters-settings:
   gofumpt:
     # Select the Go version to target. The default is `1.15`.
-    lang-version: "1.16"
+    lang-version: "1.19"
     # Choose whether or not to use the extra rules that are disabled
     # by default
     extra-rules: false

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright The Karbour Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file is the configuration file of [commitlint](https://commitlint.js.org/#/).
+//
+// Rules can be referenced: 
+// https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional
+module.exports = {extends: ['@commitlint/config-conventional']}


### PR DESCRIPTION
#### What type of PR is this?
/kind ci

#### What this PR does / why we need it:

Kusion can follows the [conventional-commits](https://www.conventionalcommits.org/en/v1.0.0/) to improve better history information. More see:

https://github.com/KusionStack/karbour/blob/main/docs/contributor/code-contribute.md#commit-message-format

So, add ci checks such as commit lint, pull request title lint.

Screenshots:

![image](https://github.com/KusionStack/kusion/assets/9360247/88805d00-f311-443b-8076-34010e8a8fce)

![image](https://github.com/KusionStack/kusion/assets/9360247/164972af-a6e4-4db0-9867-f9fda80aa312)
