### PR TITLE
feat: support default order of kubernetes resource

### DIFF
--- a/pkg/generator/appconfiguration/generator/app_configurations_generator.go
+++ b/pkg/generator/appconfiguration/generator/app_configurations_generator.go
@@ -91,6 +91,7 @@ func (g *appConfigurationGenerator) Generate(spec *models.Spec) error {
 	gfs := []appconfiguration.NewGeneratorFunc{
 		NewNamespaceGeneratorFunc(g.project.Name),
 		workload.NewWorkloadGeneratorFunc(g.project, g.stack, g.appName, g.app.Workload),
+		NewOrderedResourcesGeneratorFunc(nil),
 	}
 
 	if err := appconfiguration.CallGenerators(spec, gfs...); err != nil {

--- a/pkg/generator/appconfiguration/generator/app_configurations_generator.go
+++ b/pkg/generator/appconfiguration/generator/app_configurations_generator.go
@@ -91,7 +91,7 @@ func (g *appConfigurationGenerator) Generate(spec *models.Spec) error {
 	gfs := []appconfiguration.NewGeneratorFunc{
 		NewNamespaceGeneratorFunc(g.project.Name),
 		workload.NewWorkloadGeneratorFunc(g.project, g.stack, g.appName, g.app.Workload),
-		NewOrderedResourcesGeneratorFunc(nil),
+		NewOrderedResourcesGeneratorFunc(),
 	}
 
 	if err := appconfiguration.CallGenerators(spec, gfs...); err != nil {

--- a/pkg/generator/appconfiguration/generator/app_configurations_generator.go
+++ b/pkg/generator/appconfiguration/generator/app_configurations_generator.go
@@ -91,6 +91,7 @@ func (g *appConfigurationGenerator) Generate(spec *models.Spec) error {
 	gfs := []appconfiguration.NewGeneratorFunc{
 		NewNamespaceGeneratorFunc(g.project.Name),
 		workload.NewWorkloadGeneratorFunc(g.project, g.stack, g.appName, g.app.Workload),
+		// The OrderedResourcesGenerator should be executed after all resources are generated.
 		NewOrderedResourcesGeneratorFunc(),
 	}
 

--- a/pkg/generator/appconfiguration/generator/ordered_resources_generator.go
+++ b/pkg/generator/appconfiguration/generator/ordered_resources_generator.go
@@ -107,7 +107,7 @@ func findDependResources(dependKind string, rs []models.Resource) []*models.Reso
 }
 
 func (g *orderedResourcesGenerator) findDependKinds(curKind string) []string {
-	var dependKinds []string
+	dependKinds := make([]string, 0)
 	for _, previousKind := range g.orderedKinds {
 		if curKind == previousKind {
 			break

--- a/pkg/generator/appconfiguration/generator/ordered_resources_generator.go
+++ b/pkg/generator/appconfiguration/generator/ordered_resources_generator.go
@@ -93,11 +93,11 @@ func injectAllDependsOn(curResource *models.Resource, dependKinds []string, rs [
 // injectDependsOn injects dependsOn relationships for the given resource and dependent resources.
 func injectDependsOn(res *models.Resource, dependResources []*models.Resource) {
 	dependsOn := make([]string, 0, len(dependResources))
-	for _, r := range dependResources {
-		res.DependsOn = append(res.DependsOn, r.ID)
+	for i := 0; i < len(dependResources); i++ {
+		dependsOn = append(dependsOn, dependResources[i].ID)
 	}
 	if len(dependsOn) > 0 {
-		res.DependsOn = dependsOn
+		res.DependsOn = append(res.DependsOn, dependsOn...)
 	}
 }
 

--- a/pkg/generator/appconfiguration/generator/ordered_resources_generator.go
+++ b/pkg/generator/appconfiguration/generator/ordered_resources_generator.go
@@ -41,10 +41,10 @@ type orderedResourcesGenerator struct {
 }
 
 // NewOrderedResourcesGenerator returns a new instance of orderedResourcesGenerator.
-func NewOrderedResourcesGenerator(orderedKindsList ...[]string) (appconfiguration.Generator, error) {
+func NewOrderedResourcesGenerator(multipleOrderedKinds ...[]string) (appconfiguration.Generator, error) {
 	orderedKinds := defaultOrderedKinds
-	if len(orderedKindsList) > 0 && len(orderedKindsList[0]) > 0 {
-		orderedKinds = orderedKindsList[0]
+	if len(multipleOrderedKinds) > 0 && len(multipleOrderedKinds[0]) > 0 {
+		orderedKinds = multipleOrderedKinds[0]
 	}
 	return &orderedResourcesGenerator{
 		orderedKinds: orderedKinds,
@@ -52,9 +52,9 @@ func NewOrderedResourcesGenerator(orderedKindsList ...[]string) (appconfiguratio
 }
 
 // NewOrderedResourcesGeneratorFunc returns a function that creates a new orderedResourcesGenerator.
-func NewOrderedResourcesGeneratorFunc(orderedKindsList ...[]string) appconfiguration.NewGeneratorFunc {
+func NewOrderedResourcesGeneratorFunc(multipleOrderedKinds ...[]string) appconfiguration.NewGeneratorFunc {
 	return func() (appconfiguration.Generator, error) {
-		return NewOrderedResourcesGenerator(orderedKindsList...)
+		return NewOrderedResourcesGenerator(multipleOrderedKinds...)
 	}
 }
 

--- a/pkg/generator/appconfiguration/generator/ordered_resources_generator.go
+++ b/pkg/generator/appconfiguration/generator/ordered_resources_generator.go
@@ -7,6 +7,7 @@ import (
 	"kusionstack.io/kusion/pkg/models"
 )
 
+// defaultOrderedKinds provides the default order of kubernetes resource kinds.
 var defaultOrderedKinds = []string{
 	"Namespace",
 	"ResourceQuota",
@@ -34,10 +35,12 @@ var defaultOrderedKinds = []string{
 	"ValidatingWebhookConfiguration",
 }
 
+// orderedResourcesGenerator is a generator that inject the dependsOn of resources in a specified order.
 type orderedResourcesGenerator struct {
 	orderedKinds []string
 }
 
+// NewOrderedResourcesGenerator returns a new instance of orderedResourcesGenerator.
 func NewOrderedResourcesGenerator(orderedKindsList ...[]string) (appconfiguration.Generator, error) {
 	orderedKinds := defaultOrderedKinds
 	if len(orderedKindsList) > 0 && len(orderedKindsList[0]) > 0 {
@@ -48,38 +51,38 @@ func NewOrderedResourcesGenerator(orderedKindsList ...[]string) (appconfiguratio
 	}, nil
 }
 
+// NewOrderedResourcesGeneratorFunc returns a function that creates a new orderedResourcesGenerator.
 func NewOrderedResourcesGeneratorFunc(orderedKindsList ...[]string) appconfiguration.NewGeneratorFunc {
 	return func() (appconfiguration.Generator, error) {
 		return NewOrderedResourcesGenerator(orderedKindsList...)
 	}
 }
 
+// Generate inject the dependsOn of resources in a specified order.
 func (g *orderedResourcesGenerator) Generate(spec *models.Spec) error {
 	if spec.Resources == nil {
 		spec.Resources = make(models.Resources, 0)
 	}
-
 	for i := 0; i < len(spec.Resources); i++ {
 		if spec.Resources[i].Type != runtime.Kubernetes {
 			continue
 		}
-
 		curResource := &spec.Resources[i]
 		curKind := resourceKind(curResource)
-
 		dependKinds := g.findDependKinds(curKind)
 		injectAllDependsOn(curResource, dependKinds, spec.Resources)
 	}
-
 	return nil
 }
 
+// resourceKind returns the kind of the given resource.
 func resourceKind(r *models.Resource) string {
 	u := &unstructured.Unstructured{}
 	u.SetUnstructuredContent(r.Attributes)
 	return u.GetKind()
 }
 
+// injectAllDependsOn injects all dependsOn relationships for the given resource and dependent kinds.
 func injectAllDependsOn(curResource *models.Resource, dependKinds []string, rs []models.Resource) {
 	for _, dependKind := range dependKinds {
 		dependResources := findDependResources(dependKind, rs)
@@ -87,6 +90,7 @@ func injectAllDependsOn(curResource *models.Resource, dependKinds []string, rs [
 	}
 }
 
+// injectDependsOn injects dependsOn relationships for the given resource and dependent resources.
 func injectDependsOn(res *models.Resource, dependResources []*models.Resource) {
 	dependsOn := make([]string, 0, len(dependResources))
 	for _, r := range dependResources {
@@ -97,6 +101,7 @@ func injectDependsOn(res *models.Resource, dependResources []*models.Resource) {
 	}
 }
 
+// findDependResources returns the dependent resources of the specified kind.
 func findDependResources(dependKind string, rs []models.Resource) []*models.Resource {
 	var dependResources []*models.Resource
 	for i := 0; i < len(rs); i++ {
@@ -107,6 +112,7 @@ func findDependResources(dependKind string, rs []models.Resource) []*models.Reso
 	return dependResources
 }
 
+// findDependKinds returns the dependent resource kinds for the specified kind.
 func (g *orderedResourcesGenerator) findDependKinds(curKind string) []string {
 	dependKinds := make([]string, 0)
 	for _, previousKind := range g.orderedKinds {

--- a/pkg/generator/appconfiguration/generator/ordered_resources_generator.go
+++ b/pkg/generator/appconfiguration/generator/ordered_resources_generator.go
@@ -38,18 +38,19 @@ type orderedResourcesGenerator struct {
 	orderedKinds []string
 }
 
-func NewOrderedResourcesGenerator(orderedKinds []string) (appconfiguration.Generator, error) {
-	if len(orderedKinds) == 0 {
-		orderedKinds = defaultOrderedKinds
+func NewOrderedResourcesGenerator(orderedKindsList ...[]string) (appconfiguration.Generator, error) {
+	orderedKinds := defaultOrderedKinds
+	if len(orderedKindsList) > 0 && len(orderedKindsList[0]) > 0 {
+		orderedKinds = orderedKindsList[0]
 	}
 	return &orderedResourcesGenerator{
 		orderedKinds: orderedKinds,
 	}, nil
 }
 
-func NewOrderedResourcesGeneratorFunc(orderedKinds []string) appconfiguration.NewGeneratorFunc {
+func NewOrderedResourcesGeneratorFunc(orderedKindsList ...[]string) appconfiguration.NewGeneratorFunc {
 	return func() (appconfiguration.Generator, error) {
-		return NewOrderedResourcesGenerator(orderedKinds)
+		return NewOrderedResourcesGenerator(orderedKindsList...)
 	}
 }
 

--- a/pkg/generator/appconfiguration/generator/ordered_resources_generator.go
+++ b/pkg/generator/appconfiguration/generator/ordered_resources_generator.go
@@ -1,0 +1,118 @@
+package generator
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"kusionstack.io/kusion/pkg/engine/runtime"
+	"kusionstack.io/kusion/pkg/generator/appconfiguration"
+	"kusionstack.io/kusion/pkg/models"
+)
+
+var defaultOrderedKinds = []string{
+	"Namespace",
+	"ResourceQuota",
+	"StorageClass",
+	"CustomResourceDefinition",
+	"ServiceAccount",
+	"PodSecurityPolicy",
+	"Role",
+	"ClusterRole",
+	"RoleBinding",
+	"ClusterRoleBinding",
+	"ConfigMap",
+	"Secret",
+	"Endpoints",
+	"Service",
+	"LimitRange",
+	"PriorityClass",
+	"PersistentVolume",
+	"PersistentVolumeClaim",
+	"Deployment",
+	"StatefulSet",
+	"CronJob",
+	"PodDisruptionBudget",
+	"MutatingWebhookConfiguration",
+	"ValidatingWebhookConfiguration",
+}
+
+type orderedResourcesGenerator struct {
+	orderedKinds []string
+}
+
+func NewOrderedResourcesGenerator(orderedKinds []string) (appconfiguration.Generator, error) {
+	if len(orderedKinds) == 0 {
+		orderedKinds = defaultOrderedKinds
+	}
+	return &orderedResourcesGenerator{
+		orderedKinds: orderedKinds,
+	}, nil
+}
+
+func NewOrderedResourcesGeneratorFunc(orderedKinds []string) appconfiguration.NewGeneratorFunc {
+	return func() (appconfiguration.Generator, error) {
+		return NewOrderedResourcesGenerator(orderedKinds)
+	}
+}
+
+func (g *orderedResourcesGenerator) Generate(spec *models.Spec) error {
+	if spec.Resources == nil {
+		spec.Resources = make(models.Resources, 0)
+	}
+
+	for i := 0; i < len(spec.Resources); i++ {
+		if spec.Resources[i].Type != runtime.Kubernetes {
+			continue
+		}
+
+		curResource := &spec.Resources[i]
+		curKind := resourceKind(curResource)
+
+		dependKinds := g.findDependKinds(curKind)
+		injectAllDependsOn(curResource, dependKinds, spec.Resources)
+	}
+
+	return nil
+}
+
+func resourceKind(r *models.Resource) string {
+	u := &unstructured.Unstructured{}
+	u.SetUnstructuredContent(r.Attributes)
+	return u.GetKind()
+}
+
+func injectAllDependsOn(curResource *models.Resource, dependKinds []string, rs []models.Resource) {
+	for _, dependKind := range dependKinds {
+		dependResources := findDependResources(dependKind, rs)
+		injectDependsOn(curResource, dependResources)
+	}
+}
+
+func injectDependsOn(res *models.Resource, dependResources []*models.Resource) {
+	dependsOn := make([]string, 0, len(dependResources))
+	for _, r := range dependResources {
+		res.DependsOn = append(res.DependsOn, r.ID)
+	}
+	if len(dependsOn) > 0 {
+		res.DependsOn = dependsOn
+	}
+}
+
+func findDependResources(dependKind string, rs []models.Resource) []*models.Resource {
+	var dependResources []*models.Resource
+	for i := 0; i < len(rs); i++ {
+		if resourceKind(&rs[i]) == dependKind {
+			dependResources = append(dependResources, &rs[i])
+		}
+	}
+	return dependResources
+}
+
+func (g *orderedResourcesGenerator) findDependKinds(curKind string) []string {
+	var dependKinds []string
+	for _, previousKind := range g.orderedKinds {
+		if curKind == previousKind {
+			break
+		}
+		dependKinds = append(dependKinds, previousKind)
+	}
+	return dependKinds
+}

--- a/pkg/generator/appconfiguration/generator/ordered_resources_generator_test.go
+++ b/pkg/generator/appconfiguration/generator/ordered_resources_generator_test.go
@@ -30,6 +30,14 @@ var (
 			},
 		},
 	}
+	fakeService = map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Service",
+		"metadata": map[string]interface{}{
+			"namespace": "foo",
+			"name":      "bar",
+		},
+	}
 	fakeNamespace = map[string]interface{}{
 		"apiVersion": "v1",
 		"kind":       "Namespace",
@@ -46,6 +54,11 @@ var (
 					Attributes: fakeDeployment,
 				},
 				{
+					ID:         "v1:Service:foo:bar",
+					Type:       runtime.Kubernetes,
+					Attributes: fakeService,
+				},
+				{
 					ID:         "v1:Namespace:foo",
 					Type:       runtime.Kubernetes,
 					Attributes: fakeNamespace,
@@ -60,6 +73,12 @@ var (
 					ID:         "apps/v1:Deployment:foo:bar",
 					Type:       runtime.Kubernetes,
 					Attributes: fakeDeployment,
+					DependsOn:  []string{"v1:Namespace:foo", "v1:Service:foo:bar"},
+				},
+				{
+					ID:         "v1:Service:foo:bar",
+					Type:       runtime.Kubernetes,
+					Attributes: fakeService,
 					DependsOn:  []string{"v1:Namespace:foo"},
 				},
 				{

--- a/pkg/generator/appconfiguration/generator/ordered_resources_generator_test.go
+++ b/pkg/generator/appconfiguration/generator/ordered_resources_generator_test.go
@@ -73,7 +73,7 @@ var (
 )
 
 func TestOrderedResourcesGenerator_Generate(t *testing.T) {
-	orderedGenerator, err := NewOrderedResourcesGenerator(nil)
+	orderedGenerator, err := NewOrderedResourcesGenerator()
 	assert.NoError(t, err)
 
 	expected := genNewSpec()

--- a/pkg/generator/appconfiguration/generator/ordered_resources_generator_test.go
+++ b/pkg/generator/appconfiguration/generator/ordered_resources_generator_test.go
@@ -1,0 +1,157 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"kusionstack.io/kusion/pkg/engine/runtime"
+	"kusionstack.io/kusion/pkg/models"
+)
+
+var (
+	fakeDeployment = map[string]interface{}{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"metadata": map[string]interface{}{
+			"namespace": "foo",
+			"name":      "bar",
+		},
+		"spec": map[string]interface{}{
+			"replica": 1,
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"containers": []map[string]interface{}{
+						{
+							"image": "foo.bar.com:v1",
+							"name":  "bar",
+						},
+					},
+				},
+			},
+		},
+	}
+	fakeNamespace = map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]interface{}{
+			"name": "foo",
+		},
+	}
+	genOldSpec = func() *models.Spec {
+		return &models.Spec{
+			Resources: models.Resources{
+				{
+					ID:         "apps/v1:Deployment:foo:bar",
+					Type:       runtime.Kubernetes,
+					Attributes: fakeDeployment,
+				},
+				{
+					ID:         "v1:Namespace:foo",
+					Type:       runtime.Kubernetes,
+					Attributes: fakeNamespace,
+				},
+			},
+		}
+	}
+	genNewSpec = func() *models.Spec {
+		return &models.Spec{
+			Resources: models.Resources{
+				{
+					ID:         "apps/v1:Deployment:foo:bar",
+					Type:       runtime.Kubernetes,
+					Attributes: fakeDeployment,
+					DependsOn:  []string{"v1:Namespace:foo"},
+				},
+				{
+					ID:         "v1:Namespace:foo",
+					Type:       runtime.Kubernetes,
+					Attributes: fakeNamespace,
+				},
+			},
+		}
+	}
+)
+
+func TestOrderedResourcesGenerator_Generate(t *testing.T) {
+	orderedGenerator, err := NewOrderedResourcesGenerator(nil)
+	assert.NoError(t, err)
+
+	expected := genNewSpec()
+	actual := genOldSpec()
+	err = orderedGenerator.Generate(actual)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestResourceKind(t *testing.T) {
+	resource := &models.Resource{
+		Type: runtime.Kubernetes,
+		Attributes: map[string]interface{}{
+			"kind": "Deployment",
+		},
+	}
+
+	expected := "Deployment"
+	actual := resourceKind(resource)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestInjectAllDependsOn(t *testing.T) {
+	spec := genOldSpec()
+	dependKinds := []string{"Namespace"}
+
+	expected := []string{"v1:Namespace:foo"}
+	actual := []models.Resource(spec.Resources)[0]
+	injectAllDependsOn(&actual, dependKinds, spec.Resources)
+
+	assert.Equal(t, expected, actual.DependsOn)
+}
+
+func TestFindDependKinds(t *testing.T) {
+	curKind := "Deployment"
+	g := &orderedResourcesGenerator{
+		orderedKinds: defaultOrderedKinds,
+	}
+
+	expected := []string{
+		"Namespace",
+		"ResourceQuota",
+		"StorageClass",
+		"CustomResourceDefinition",
+		"ServiceAccount",
+		"PodSecurityPolicy",
+		"Role",
+		"ClusterRole",
+		"RoleBinding",
+		"ClusterRoleBinding",
+		"ConfigMap",
+		"Secret",
+		"Endpoints",
+		"Service",
+		"LimitRange",
+		"PriorityClass",
+		"PersistentVolume",
+		"PersistentVolumeClaim",
+	}
+	actual := g.findDependKinds(curKind)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestFindDependResources(t *testing.T) {
+	dependKind := "Namespace"
+	resources := genOldSpec().Resources
+
+	expected := []*models.Resource{
+		{
+			ID:         "v1:Namespace:foo",
+			Type:       runtime.Kubernetes,
+			Attributes: fakeNamespace,
+		},
+	}
+	actual := findDependResources(dependKind, resources)
+
+	assert.Equal(t, expected, actual)
+}

--- a/pkg/generator/appconfiguration/generator/ordered_resources_generator_test.go
+++ b/pkg/generator/appconfiguration/generator/ordered_resources_generator_test.go
@@ -104,7 +104,7 @@ func TestOrderedResourcesGenerator_Generate(t *testing.T) {
 }
 
 func TestResourceKind(t *testing.T) {
-	resource := &models.Resource{
+	r := &resource{
 		Type: runtime.Kubernetes,
 		Attributes: map[string]interface{}{
 			"kind": "Deployment",
@@ -112,7 +112,7 @@ func TestResourceKind(t *testing.T) {
 	}
 
 	expected := "Deployment"
-	actual := resourceKind(resource)
+	actual := r.kubernetesKind()
 
 	assert.Equal(t, expected, actual)
 }
@@ -122,16 +122,18 @@ func TestInjectAllDependsOn(t *testing.T) {
 	dependKinds := []string{"Namespace"}
 
 	expected := []string{"v1:Namespace:foo"}
-	actual := []models.Resource(spec.Resources)[0]
-	injectAllDependsOn(&actual, dependKinds, spec.Resources)
+	actual := resource([]models.Resource(spec.Resources)[0])
+	actual.injectDependsOn(dependKinds, spec.Resources)
 
 	assert.Equal(t, expected, actual.DependsOn)
 }
 
 func TestFindDependKinds(t *testing.T) {
-	curKind := "Deployment"
-	g := &orderedResourcesGenerator{
-		orderedKinds: defaultOrderedKinds,
+	r := &resource{
+		Type: runtime.Kubernetes,
+		Attributes: map[string]interface{}{
+			"kind": "Deployment",
+		},
 	}
 
 	expected := []string{
@@ -154,7 +156,7 @@ func TestFindDependKinds(t *testing.T) {
 		"PersistentVolume",
 		"PersistentVolumeClaim",
 	}
-	actual := g.findDependKinds(curKind)
+	actual := r.findDependKinds(defaultOrderedKinds)
 
 	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Support default order of kubernetes resource.

```go
var defaultOrderedKinds = []string{
	"Namespace",
	"ResourceQuota",
	"StorageClass",
	"CustomResourceDefinition",
	"ServiceAccount",
	"PodSecurityPolicy",
	"Role",
	"ClusterRole",
	"RoleBinding",
	"ClusterRoleBinding",
	"ConfigMap",
	"Secret",
	"Endpoints",
	"Service",
	"LimitRange",
	"PriorityClass",
	"PersistentVolume",
	"PersistentVolumeClaim",
	"Deployment",
	"StatefulSet",
	"CronJob",
	"PodDisruptionBudget",
	"MutatingWebhookConfiguration",
	"ValidatingWebhookConfiguration",
}
```