### PR TITLE
fix: port in probe url now gets parsed properly

### DIFF
--- a/pkg/generator/appconfiguration/generator/workload/workload_generator.go
+++ b/pkg/generator/appconfiguration/generator/workload/workload_generator.go
@@ -304,7 +304,7 @@ func httpGetAction(urlstr string, headers map[string]string) (*corev1.HTTPGetAct
 
 	return &corev1.HTTPGetAction{
 		Path:        u.Path,
-		Port:        intstr.FromString(u.Port()),
+		Port:        intstr.Parse(u.Port()),
 		Host:        u.Hostname(),
 		Scheme:      corev1.URIScheme(strings.ToUpper(u.Scheme)),
 		HTTPHeaders: httpHeaders,
@@ -318,7 +318,7 @@ func tcpSocketAction(urlstr string) (*corev1.TCPSocketAction, error) {
 	}
 
 	return &corev1.TCPSocketAction{
-		Port: intstr.FromString(port),
+		Port: intstr.Parse(port),
 		Host: host,
 	}, nil
 }


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

The URL in Probe model gets parsed and put into the corev1.Probe object.
The port gets parsed by `intstr.FromString(u.Port())` which ends up being a string in the rendered yaml:
<img width="192" alt="image" src="https://github.com/KusionStack/kusion/assets/5624244/fb4dd7bb-6a3a-4387-b900-b0b140da2cbb">
This is rejected by Kubernetes because for a string port (as the port name) it expects at least one letter in it:
<img width="1566" alt="image" src="https://github.com/KusionStack/kusion/assets/5624244/7eb56b88-83b4-418f-8914-381e272ede28">
[`intstr.Parse()`](https://pkg.go.dev/k8s.io/apimachinery@v0.27.2/pkg/util/intstr#Parse) will attempt to convert the string to an int first which is what we want.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
