### PR TITLE
fix: set host to empty when url parse get localhost or 127.0.0.1

### DIFF
--- a/pkg/generator/appconfiguration/generator/workload/workload_generator.go
+++ b/pkg/generator/appconfiguration/generator/workload/workload_generator.go
@@ -312,10 +312,15 @@ func httpGetAction(urlstr string, headers map[string]string) (*corev1.HTTPGetAct
 		})
 	}
 
+	host := u.Hostname()
+	if host == "localhost" || host == "127.0.0.1" {
+		host = ""
+	}
+
 	return &corev1.HTTPGetAction{
 		Path:        u.Path,
 		Port:        intstr.Parse(u.Port()),
-		Host:        u.Hostname(),
+		Host:        host,
 		Scheme:      corev1.URIScheme(strings.ToUpper(u.Scheme)),
 		HTTPHeaders: httpHeaders,
 	}, nil

--- a/pkg/generator/appconfiguration/generator/workload/workload_generator_test.go
+++ b/pkg/generator/appconfiguration/generator/workload/workload_generator_test.go
@@ -266,7 +266,7 @@ func TestToOrderedContainers(t *testing.T) {
 		assert.Equal(t, "HTTP", string(actualContainers[0].ReadinessProbe.HTTPGet.Scheme), "HTTPGet.Scheme mismatch")
 		assert.Equal(t, "/readiness", actualContainers[0].ReadinessProbe.HTTPGet.Path, "HTTPGet.Path mismatch")
 		assert.Equal(t, "8080", actualContainers[0].ReadinessProbe.HTTPGet.Port.String(), "HTTPGet.Port mismatch")
-		assert.Equal(t, "localhost", actualContainers[0].ReadinessProbe.HTTPGet.Host, "HTTPGet.Host mismatch")
+		assert.Equal(t, "", actualContainers[0].ReadinessProbe.HTTPGet.Host, "HTTPGet.Host mismatch")
 		assert.Equal(t, 1, len(actualContainers[0].ReadinessProbe.HTTPGet.HTTPHeaders), "HTTPGet.HTTPHeaders length mismatch")
 
 		assert.NotNil(t, actualContainers[0].LivenessProbe, "LivenessProbe should not be nil")
@@ -323,7 +323,7 @@ func TestToOrderedContainers(t *testing.T) {
 		assert.Equal(t, "HTTP", string(actualContainers[0].Lifecycle.PostStart.HTTPGet.Scheme), "PostStart.HTTPGet.Scheme mismatch")
 		assert.Equal(t, "/readiness", actualContainers[0].Lifecycle.PostStart.HTTPGet.Path, "PostStart.HTTPGet.Path mismatch")
 		assert.Equal(t, "8080", actualContainers[0].Lifecycle.PostStart.HTTPGet.Port.String(), "PostStart.HTTPGet.Port mismatch")
-		assert.Equal(t, "localhost", actualContainers[0].Lifecycle.PostStart.HTTPGet.Host, "PostStart.HTTPGet.Host mismatch")
+		assert.Equal(t, "", actualContainers[0].Lifecycle.PostStart.HTTPGet.Host, "PostStart.HTTPGet.Host mismatch")
 		assert.Equal(t, 1, len(actualContainers[0].Lifecycle.PostStart.HTTPGet.HTTPHeaders), "PostStart.HTTPGet.HTTPHeaders length mismatch")
 	})
 }


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:
set probe http action path to empty when url parse resolve localhost
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
