### PR TITLE
fix: don't generate a ruleset when the ops rule is empty

### DIFF
--- a/pkg/generator/appconfiguration/generator/app_configurations_generator.go
+++ b/pkg/generator/appconfiguration/generator/app_configurations_generator.go
@@ -6,6 +6,7 @@ import (
 	"kusionstack.io/kusion/pkg/generator"
 	"kusionstack.io/kusion/pkg/generator/appconfiguration"
 	accessories "kusionstack.io/kusion/pkg/generator/appconfiguration/generator/accessories/database"
+	"kusionstack.io/kusion/pkg/generator/appconfiguration/generator/trait"
 	"kusionstack.io/kusion/pkg/generator/appconfiguration/generator/workload"
 	"kusionstack.io/kusion/pkg/models"
 	appmodel "kusionstack.io/kusion/pkg/models/appconfiguration"
@@ -93,6 +94,7 @@ func (g *appConfigurationGenerator) Generate(spec *models.Spec) error {
 		NewNamespaceGeneratorFunc(g.project.Name),
 		accessories.NewDatabaseGeneratorFunc(g.project, g.stack, g.appName, g.app.Workload, g.app.Database),
 		workload.NewWorkloadGeneratorFunc(g.project, g.stack, g.appName, g.app.Workload, g.app.Monitoring, g.app.OpsRule),
+		trait.NewOpsRuleGeneratorFunc(g.project, g.stack, g.appName, g.app),
 		NewMonitoringGeneratorFunc(g.project, g.app.Monitoring, g.appName),
 		// The OrderedResourcesGenerator should be executed after all resources are generated.
 		NewOrderedResourcesGeneratorFunc(),

--- a/pkg/generator/appconfiguration/generator/trait/ops_rule_generator.go
+++ b/pkg/generator/appconfiguration/generator/trait/ops_rule_generator.go
@@ -45,6 +45,10 @@ func NewOpsRuleGeneratorFunc(
 }
 
 func (g *opsRuleGenerator) Generate(spec *models.Spec) error {
+	if g.app.OpsRule == nil {
+		return nil
+	}
+
 	if g.app.Workload.Header.Type != workload.TypeService {
 		return nil
 	}


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:
don't generate a ruleset when the ops rule is empty
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
