### PR TITLE
fix: delete external templates when init --online failed

### DIFF
--- a/pkg/scaffold/templates_test.go
+++ b/pkg/scaffold/templates_test.go
@@ -165,23 +165,6 @@ func TestRetrieveTemplates(t *testing.T) {
 	})
 }
 
-func Test_cleanupLegacyTemplateDir(t *testing.T) {
-	t.Run("repo not exist", func(t *testing.T) {
-		defer monkey.UnpatchAll()
-		monkey.Patch(GetTemplateDir, func(subDir string) (string, error) {
-			return os.MkdirTemp("", "tmp-dir-for-test")
-		})
-
-		err = cleanupLegacyTemplateDir()
-		assert.Nil(t, err)
-	})
-
-	t.Run("clean nothing", func(t *testing.T) {
-		err = cleanupLegacyTemplateDir()
-		assert.Nil(t, err)
-	})
-}
-
 func TestValidateProjectName(t *testing.T) {
 	type args struct {
 		s string


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:
always delete external templates in init with the online flag
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #368

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
