### PR TITLE
feat: add kubeConfig from workspace in extensions when kusion build

### DIFF
--- a/pkg/apis/stack/types.go
+++ b/pkg/apis/stack/types.go
@@ -17,8 +17,7 @@ var (
 
 // Configuration is the stack configuration
 type Configuration struct {
-	Name       string `json:"name" yaml:"name"`             // Stack name
-	KubeConfig string `json:"kubeConfig" yaml:"kubeConfig"` // KubeConfig file path for this stack
+	Name string `json:"name" yaml:"name"` // Stack name
 }
 
 type Stack struct {

--- a/pkg/cmd/build/util_test.go
+++ b/pkg/cmd/build/util_test.go
@@ -114,7 +114,8 @@ resources:
 					},
 				},
 				Extensions: map[string]interface{}{
-					"GVK": "/v1, Kind=Namespace",
+					"GVK":        "/v1, Kind=Namespace",
+					"kubeConfig": "/etc/kubeconfig.yaml",
 				},
 			},
 		},

--- a/pkg/modules/generators/app_configurations_generator.go
+++ b/pkg/modules/generators/app_configurations_generator.go
@@ -74,9 +74,9 @@ func NewAppConfigurationGeneratorFunc(
 	}
 }
 
-func (g *appConfigurationGenerator) Generate(spec *intent.Intent) error {
-	if spec.Resources == nil {
-		spec.Resources = make(intent.Resources, 0)
+func (g *appConfigurationGenerator) Generate(i *intent.Intent) error {
+	if i.Resources == nil {
+		i.Resources = make(intent.Resources, 0)
 	}
 
 	// Generate resources
@@ -89,7 +89,7 @@ func (g *appConfigurationGenerator) Generate(spec *intent.Intent) error {
 		// The OrderedResourcesGenerator should be executed after all resources are generated.
 		NewOrderedResourcesGeneratorFunc(),
 	}
-	if err := modules.CallGenerators(spec, gfs...); err != nil {
+	if err := modules.CallGenerators(i, gfs...); err != nil {
 		return err
 	}
 
@@ -98,9 +98,12 @@ func (g *appConfigurationGenerator) Generate(spec *intent.Intent) error {
 		pattrait.NewOpsRulePatcherFunc(g.app),
 		patmonitoring.NewMonitoringPatcherFunc(g.appName, g.app, g.project),
 	}
-	if err := modules.CallPatchers(spec.Resources.GVKIndex(), pfs...); err != nil {
+	if err := modules.CallPatchers(i.Resources.GVKIndex(), pfs...); err != nil {
 		return err
 	}
+
+	// Add kubeConfig from workspace if exist
+	modules.AddKubeConfigIf(i, g.ws)
 
 	return nil
 }


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add kubeConfig from workspace in extensions when kusion build.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #655 
