### PR TITLE
fix: misuse of env KUSION_PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update -y && apt-get install python3 python3-pip -y
 # KCL PATH
 ENV PATH="/root/go/bin:${PATH}"
 # KUSION_PATH
-ENV KUSION_PATH="$HOME/.kusion"
+ENV KUSION_HOME="$HOME/.kusion"
+ENV KUSION_PATH="$KUSION_HOME/bin"
 ENV LANG=en_US.utf8
 
 FROM base AS goreleaser

--- a/Dockerfile_kusionctl
+++ b/Dockerfile_kusionctl
@@ -5,5 +5,6 @@ COPY _build/bundles/kusion-linux/bin/kusion /kusion/bin/
 RUN chmod +x /kusion/bin/kusion
 
 ENV PATH="/kusion/bin:${PATH}"
-ENV KUSION_PATH="/kusion"
+ENV KUSION_HOME="/kusion"
+ENV KUSION_PATH="$KUSION_HOME/bin"
 ENV LANG=en_US.utf8

--- a/pkg/util/kfile/file.go
+++ b/pkg/util/kfile/file.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	EnvKusionPath = "KUSION_PATH"
+	EnvKusionHome = "KUSION_HOME"
 	// CachedVersionFile is the name of the file we use to store when we last checked if the CLI was out of date
 	CachedVersionFile = ".cached_version"
 )
@@ -62,7 +62,7 @@ func FileExists(filename string) (bool, error) {
 func KusionDataFolder() (string, error) {
 	var kusionDataFolder string
 
-	if kusionPath := os.Getenv(EnvKusionPath); kusionPath != "" {
+	if kusionPath := os.Getenv(EnvKusionHome); kusionPath != "" {
 		kusionDataFolder = kusionPath
 	} else {
 		usr, err := user.Current()

--- a/pkg/util/kfile/file_test.go
+++ b/pkg/util/kfile/file_test.go
@@ -72,7 +72,7 @@ func TestKusionDataFolder(t *testing.T) {
 	for _, tt := range tests {
 		mockey.PatchConvey(tt.name, t, func() {
 			// Mock data
-			os.Setenv(EnvKusionPath, "")
+			os.Setenv(EnvKusionHome, "")
 			mockUserCurrent()
 			mockMkdirall()
 			got, err := KusionDataFolder()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Use the value of env `KUSION_HOME` instead of `KUSION_PATH` as the path to store kusion data, cause the former is `$HOME/.kusion` and the latter is `$HOME/.kusion/bin`. This change happens when changing the catalog of kusion package.