### PR TITLE
feat: delete server side fields in kubernetes runtime

### DIFF
--- a/pkg/engine/runtime/kubernetes/kubernetes_runtime.go
+++ b/pkg/engine/runtime/kubernetes/kubernetes_runtime.go
@@ -153,6 +153,10 @@ func (k *KubernetesRuntime) Apply(ctx context.Context, request *runtime.ApplyReq
 		res = planObj
 	}
 
+	// Ignore the redundant fields automatically added by the K8s server for a
+	// more concise and clean resource object.
+	normalizeServerSideFields(res)
+
 	return &runtime.ApplyResponse{Resource: &apiv1.Resource{
 		ID:         planState.ResourceKey(),
 		Type:       planState.Type,
@@ -193,6 +197,10 @@ func (k *KubernetesRuntime) Read(ctx context.Context, request *runtime.ReadReque
 		}
 		return &runtime.ReadResponse{Status: v1.NewErrorStatus(err)}
 	}
+
+	// Ignore the redundant fields automatically added by the K8s server for a
+	// more concise and clean resource object.
+	normalizeServerSideFields(v)
 
 	return &runtime.ReadResponse{Resource: &apiv1.Resource{
 		ID:         requestResource.ResourceKey(),
@@ -235,7 +243,6 @@ func (k *KubernetesRuntime) Import(ctx context.Context, request *runtime.ImportR
 				}
 			}
 		}
-		normalizeServerSideFields(ur)
 	}
 	response.Resource.Attributes = ur.Object
 	return &runtime.ImportResponse{

--- a/pkg/engine/runtime/kubernetes/kubernetes_runtime.go
+++ b/pkg/engine/runtime/kubernetes/kubernetes_runtime.go
@@ -233,14 +233,12 @@ func (k *KubernetesRuntime) Import(ctx context.Context, request *runtime.ImportR
 		if err != nil {
 			return &runtime.ImportResponse{Status: v1.NewErrorStatusWithCode(v1.IllegalManifest, err)}
 		}
-	} else {
+	} else if convertor.Service == ur.GetKind() {
 		// normalize resources
-		if convertor.Service == ur.GetKind() {
-			if err := normalizeService(ur); err != nil {
-				return &runtime.ImportResponse{
-					Resource: nil,
-					Status:   v1.NewErrorStatusWithCode(v1.IllegalManifest, err),
-				}
+		if err := normalizeService(ur); err != nil {
+			return &runtime.ImportResponse{
+				Resource: nil,
+				Status:   v1.NewErrorStatusWithCode(v1.IllegalManifest, err),
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind feature
#### What this PR does / why we need it:
This PR deletes server-side fields in Kubernetes runtime for a more precise and clean resource object. 

- Before: 
![image](https://github.com/KusionStack/kusion/assets/78610302/2571889a-b8b6-4899-937e-63199b829eae)

- After: 
![image](https://github.com/KusionStack/kusion/assets/78610302/99f55dd5-df30-46ef-950a-48f2ebecb9d9)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #705 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
