### PR TITLE
fix: add options sub-cmd for kusion

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/kubectl/pkg/cmd/options"
 	"k8s.io/kubectl/pkg/util/templates"
 
 	"kusionstack.io/kusion/pkg/cmd/apply"
@@ -114,6 +115,7 @@ func NewKusionctlCmd(o KusionctlOptions) *cobra.Command {
 
 	templates.ActsAsRootCommand(cmds, filters, groups...)
 	cmds.AddCommand(version.NewCmdVersion())
+	cmds.AddCommand(options.NewCmdOptions(o.IOStreams.Out))
 
 	return cmds
 }


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug
#### What this PR does / why we need it:
This PR adds `options` sub-cmd for kusion root command and fix the wrong `--help` info. 

For example, below is the previous `--help` info of `kusion init`: 
![image](https://github.com/KusionStack/kusion/assets/78610302/5ff20d80-bd14-4b34-8184-defab68dcce3)


And this is the result after the bug fix: 
![image](https://github.com/KusionStack/kusion/assets/78610302/7a22adc3-fdb4-4470-b784-cd35a569f2dc)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #772 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
