### PR TITLE
feat: kusion init supports the default workspace creation

### DIFF
--- a/pkg/cmd/init/options.go
+++ b/pkg/cmd/init/options.go
@@ -11,8 +11,10 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/pterm/pterm"
 
+	v1 "kusionstack.io/kusion/pkg/apis/core/v1"
 	"kusionstack.io/kusion/pkg/log"
 	"kusionstack.io/kusion/pkg/scaffold"
+	"kusionstack.io/kusion/pkg/workspace"
 )
 
 const jsonOutput = "json"
@@ -198,6 +200,13 @@ func (o *Options) Run() error {
 	}
 
 	fmt.Printf("Created project '%s'\n", o.ProjectName)
+
+	// Create the default workspace for the initiated project.
+	if err = createDefaultWorkspace(); err != nil {
+		return fmt.Errorf("failed to create the default workspace: %w", err)
+	}
+
+	fmt.Println("Created the default workspace")
 
 	return nil
 }
@@ -440,4 +449,19 @@ func promptValue(valueType string, description string, defaultValue string, isVa
 		break
 	}
 	return value, nil
+}
+
+// createDefaultWorkspace creates the default workspace.
+func createDefaultWorkspace() error {
+	ws := &v1.Workspace{
+		Name: "default",
+	}
+
+	if err := workspace.CreateWorkspaceByDefaultOperator(ws); err != nil {
+		if !errors.Is(err, workspace.ErrWorkspaceAlreadyExist) {
+			return err
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind feature
#### What this PR does / why we need it:
This PR supports the default workspace creation when using `kusion init`. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #783 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
