### PR TITLE
fix: no assignment of releaseVersion when version in buildInfo is empty

### DIFF
--- a/pkg/version/types.go
+++ b/pkg/version/types.go
@@ -33,7 +33,7 @@ func NewMainOrDefaultVersionInfo() *Info {
 			mod = mod.Replace
 		}
 
-		if mod.Version != "(devel)" {
+		if mod.Version != "(devel)" && mod.Version != "" {
 			v.ReleaseVersion = mod.Version
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
no assignment of releaseVersion when version in buildInfo is empty

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #818
