### PR TITLE
feat: update yaml package for appconfiguration generator

### DIFF
--- a/pkg/modules/generators/app_configurations_generator.go
+++ b/pkg/modules/generators/app_configurations_generator.go
@@ -5,11 +5,12 @@ import (
 	"errors"
 	"fmt"
 
-	"gopkg.in/yaml.v2"
+	yamlv2 "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"kusionstack.io/kusion/pkg/apis/core/v1"
+	v1 "kusionstack.io/kusion/pkg/apis/core/v1"
 	"kusionstack.io/kusion/pkg/log"
 	"kusionstack.io/kusion/pkg/modules"
 	"kusionstack.io/kusion/pkg/modules/generators/workload"
@@ -316,7 +317,7 @@ func (g *appConfigurationGenerator) initModuleRequest(key string, platformModule
 	// Attention: we MUST yaml.v2 to serialize the object,
 	// because we have introduced MapSlice in the Workload which is supported only in the yaml.v2
 	if g.app.Workload != nil {
-		if workloadConfig, err = yaml.Marshal(g.app.Workload); err != nil {
+		if workloadConfig, err = yamlv2.Marshal(g.app.Workload); err != nil {
 			return nil, fmt.Errorf("marshal workload config failed. %w", err)
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind feature
#### What this PR does / why we need it:
This updates the use of the yaml package in app_configurations_generator, unmarshaling `Workload` with **yaml.v2** and unmarshaling other generator request attributes with **yaml.v3**. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #940 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
