### PR TITLE
fix: add workdir to meta flag of kusion cli

### DIFF
--- a/pkg/cmd/meta/meta.go
+++ b/pkg/cmd/meta/meta.go
@@ -31,6 +31,8 @@ type MetaFlags struct {
 	Workspace *string
 
 	Backend *string
+
+	WorkDir *string
 }
 
 // MetaOptions are the meta-options that are available on all or most commands.
@@ -52,10 +54,12 @@ type MetaOptions struct {
 func NewMetaFlags() *MetaFlags {
 	workspace := ""
 	backendType := ""
+	workDir := ""
 
 	return &MetaFlags{
 		Workspace: &workspace,
 		Backend:   &backendType,
+		WorkDir:   &workDir,
 	}
 }
 
@@ -67,6 +71,9 @@ func (f *MetaFlags) AddFlags(cmd *cobra.Command) {
 	if f.Backend != nil {
 		cmd.Flags().StringVarP(f.Backend, "backend", "", *f.Backend, i18n.T("The backend to use, supports 'local', 'oss' and 's3'."))
 	}
+	if f.WorkDir != nil {
+		cmd.Flags().StringVarP(f.WorkDir, "workdir", "", *f.WorkDir, i18n.T("The work directory to run Kusion CLI."))
+	}
 }
 
 // ToOptions converts MetaFlags to MetaOptions.
@@ -74,7 +81,15 @@ func (f *MetaFlags) ToOptions() (*MetaOptions, error) {
 	opts := &MetaOptions{}
 
 	// Parse project and currentStack of work directory
-	refProject, refStack, err := project.DetectProjectAndStacks()
+	var refProject *v1.Project
+	var refStack *v1.Stack
+	var err error
+	if f.WorkDir != nil && *f.WorkDir != "" {
+		refProject, refStack, err = project.DetectProjectAndStackFrom(*f.WorkDir)
+	} else {
+		refProject, refStack, err = project.DetectProjectAndStacks()
+	}
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug
#### What this PR does / why we need it:
This PR adds `--workdir` to meta flags of Kusion CLI. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1064 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
