### PR TITLE
test: restore e2e tests after updating modules

### DIFF
--- a/test/e2e/kusionctl_test.go
+++ b/test/e2e/kusionctl_test.go
@@ -1,10 +1,18 @@
 package e2e
 
 import (
+	"context"
+	"fmt"
+	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var _ = ginkgo.Describe("Kusion Configuration Commands", func() {
@@ -20,9 +28,7 @@ var _ = ginkgo.Describe("Kusion Configuration Commands", func() {
 })
 
 var _ = ginkgo.Describe("kusion Runtime Commands", func() {
-	// comment out before we have upgrade modules in the registry
-
-	/* ginkgo.It("kusion preview", func() {
+	ginkgo.It("kusion preview", func() {
 		path := filepath.Join(GetWorkDir(), "konfig", "example", "service-multi-stack", "dev")
 		_, err := ExecKusionWithWorkDir("kusion preview -d", path)
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -64,7 +70,7 @@ var _ = ginkgo.Describe("kusion Runtime Commands", func() {
 				return errors.IsNotFound(err)
 			}, 300*time.Second, 5*time.Second).Should(gomega.Equal(true))
 		})
-	}) */
+	})
 })
 
 var _ = ginkgo.Describe("Kusion Other Commands", func() {

--- a/test/e2e/kusionctl_test.go
+++ b/test/e2e/kusionctl_test.go
@@ -30,7 +30,7 @@ var _ = ginkgo.Describe("Kusion Configuration Commands", func() {
 var _ = ginkgo.Describe("kusion Runtime Commands", func() {
 	ginkgo.It("kusion preview", func() {
 		path := filepath.Join(GetWorkDir(), "konfig", "example", "service-multi-stack", "dev")
-		_, err := ExecKusionWithWorkDir("kusion preview -d", path)
+		_, err := ExecKusionWithWorkDir("kusion preview -d=false", path)
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 	})
 


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind test
#### What this PR does / why we need it:
This PR restores the e2e tests of Kusion CLI after updating the Kusion modules. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
