### PR TITLE
fix: import the secrets register pkg in appconfig generator to regist supported secret providers

### DIFF
--- a/pkg/apis/api.kusion.io/v1/types.go
+++ b/pkg/apis/api.kusion.io/v1/types.go
@@ -90,7 +90,7 @@ type Workspace struct {
 	Modules ModuleConfigs `yaml:"modules,omitempty" json:"modules,omitempty"`
 
 	// SecretStore represents a secure external location for storing secrets.
-	SecretStore *SecretStoreSpec `yaml:"secretStore,omitempty" json:"secretStore,omitempty"`
+	SecretStore *SecretStore `yaml:"secretStore,omitempty" json:"secretStore,omitempty"`
 
 	// Context contains workspace-level configurations, such as topologies, server endpoints, metadata, etc.
 	Context GenericConfig `yaml:"context,omitempty" json:"context,omitempty"`
@@ -700,8 +700,8 @@ type ExternalSecretRef struct {
 	Property string `yaml:"property,omitempty" json:"property,omitempty"`
 }
 
-// SecretStoreSpec contains configuration to describe target secret store.
-type SecretStoreSpec struct {
+// SecretStore contains configuration to describe target secret store.
+type SecretStore struct {
 	Provider *ProviderSpec `yaml:"provider" json:"provider"`
 }
 

--- a/pkg/modules/generators/app_configurations_generator.go
+++ b/pkg/modules/generators/app_configurations_generator.go
@@ -34,6 +34,8 @@ import (
 	"kusionstack.io/kusion/pkg/modules"
 	"kusionstack.io/kusion/pkg/modules/generators/workload"
 	"kusionstack.io/kusion/pkg/modules/proto"
+	// import the secrets register pkg to register supported secret providers
+	_ "kusionstack.io/kusion/pkg/secrets/providers/register"
 	jsonutil "kusionstack.io/kusion/pkg/util/json"
 	"kusionstack.io/kusion/pkg/workspace"
 )
@@ -125,6 +127,7 @@ func (g *appConfigurationGenerator) Generate(spec *v1.Spec) error {
 			Namespace:       namespace,
 			Workload:        g.app.Workload,
 			PlatformConfigs: projectModuleConfigs,
+			SecretStoreSpec: g.ws.SecretStore,
 		}),
 	}
 	if err = modules.CallGenerators(spec, gfs...); err != nil {

--- a/pkg/modules/generators/workload/secret/secret_generator_test.go
+++ b/pkg/modules/generators/workload/secret/secret_generator_test.go
@@ -16,7 +16,7 @@ var testProject = "helloworld"
 func initGeneratorRequest(
 	project string,
 	secrets map[string]v1.Secret,
-	secretStoreSpec *v1.SecretStoreSpec,
+	secretStoreSpec *v1.SecretStore,
 ) *GeneratorRequest {
 	return &GeneratorRequest{
 		Project: project,
@@ -27,13 +27,13 @@ func initGeneratorRequest(
 				},
 			},
 		},
-		Namespace:       project,
-		SecretStoreSpec: secretStoreSpec,
+		Namespace:   project,
+		SecretStore: secretStoreSpec,
 	}
 }
 
-func initSecretStoreSpec(data []v1.FakeProviderData) *v1.SecretStoreSpec {
-	return &v1.SecretStoreSpec{
+func initSecretStoreSpec(data []v1.FakeProviderData) *v1.SecretStore {
+	return &v1.SecretStore{
 		Provider: &v1.ProviderSpec{
 			Fake: &v1.FakeProvider{
 				Data: data,

--- a/pkg/modules/generators/workload/workload_generator.go
+++ b/pkg/modules/generators/workload/workload_generator.go
@@ -35,7 +35,7 @@ type Generator struct {
 	// PlatformConfigs represents the module platform configurations
 	PlatformConfigs map[string]v1.GenericConfig
 	// SecretStoreSpec contains configuration to describe target secret store.
-	SecretStoreSpec *v1.SecretStoreSpec
+	SecretStoreSpec *v1.SecretStore
 }
 
 func NewWorkloadGeneratorFunc(g *Generator) modules.NewGeneratorFunc {
@@ -67,17 +67,17 @@ func (g *Generator) Generate(spec *v1.Spec) error {
 		switch g.Workload.Header.Type {
 		case v1.TypeService:
 			gfs = append(gfs, NewWorkloadServiceGeneratorFunc(g), secret.NewSecretGeneratorFunc(&secret.GeneratorRequest{
-				Project:         g.Project,
-				Namespace:       g.Namespace,
-				Workload:        g.Workload,
-				SecretStoreSpec: g.SecretStoreSpec,
+				Project:     g.Project,
+				Namespace:   g.Namespace,
+				Workload:    g.Workload,
+				SecretStore: g.SecretStoreSpec,
 			}))
 		case v1.TypeJob:
 			gfs = append(gfs, NewJobGeneratorFunc(g), secret.NewSecretGeneratorFunc(&secret.GeneratorRequest{
-				Project:         g.Project,
-				Namespace:       g.Namespace,
-				Workload:        g.Workload,
-				SecretStoreSpec: g.SecretStoreSpec,
+				Project:     g.Project,
+				Namespace:   g.Namespace,
+				Workload:    g.Workload,
+				SecretStore: g.SecretStoreSpec,
 			}))
 		}
 

--- a/pkg/secrets/interfaces.go
+++ b/pkg/secrets/interfaces.go
@@ -15,7 +15,7 @@ type SecretStore interface {
 // SecretStoreProvider is a factory type for secret store.
 type SecretStoreProvider interface {
 	// NewSecretStore constructs a usable secret store with specific provider spec.
-	NewSecretStore(spec v1.SecretStoreSpec) (SecretStore, error)
+	NewSecretStore(spec v1.SecretStore) (SecretStore, error)
 }
 
 var NoSecretErr = NoSecretError{}

--- a/pkg/secrets/providers/alicloud/secretsmanager/secretsmanager.go
+++ b/pkg/secrets/providers/alicloud/secretsmanager/secretsmanager.go
@@ -41,7 +41,7 @@ type smSecretStore struct {
 }
 
 // NewSecretStore constructs a Vault based secret store with specific secret store spec.
-func (p *DefaultSecretStoreProvider) NewSecretStore(spec v1.SecretStoreSpec) (secrets.SecretStore, error) {
+func (p *DefaultSecretStoreProvider) NewSecretStore(spec v1.SecretStore) (secrets.SecretStore, error) {
 	providerSpec := spec.Provider
 	if providerSpec == nil {
 		return nil, fmt.Errorf(errMissingProviderSpec)

--- a/pkg/secrets/providers/alicloud/secretsmanager/secretsmanager_test.go
+++ b/pkg/secrets/providers/alicloud/secretsmanager/secretsmanager_test.go
@@ -114,21 +114,21 @@ func TestGetSecret(t *testing.T) {
 
 func TestNewSecretStore(t *testing.T) {
 	testCases := map[string]struct {
-		spec        v1.SecretStoreSpec
+		spec        v1.SecretStore
 		expectedErr error
 	}{
 		"InvalidSecretStoreSpec": {
-			spec:        v1.SecretStoreSpec{},
+			spec:        v1.SecretStore{},
 			expectedErr: errors.New(errMissingProviderSpec),
 		},
 		"InvalidProviderSpec": {
-			spec: v1.SecretStoreSpec{
+			spec: v1.SecretStore{
 				Provider: &v1.ProviderSpec{},
 			},
 			expectedErr: errors.New(errMissingAlicloudProvider),
 		},
 		"ValidVaultProviderSpec": {
-			spec: v1.SecretStoreSpec{
+			spec: v1.SecretStore{
 				Provider: &v1.ProviderSpec{
 					Alicloud: &v1.AlicloudProvider{
 						Region: "cn-beijing",

--- a/pkg/secrets/providers/aws/secretsmanager/secretsmanager.go
+++ b/pkg/secrets/providers/aws/secretsmanager/secretsmanager.go
@@ -30,7 +30,7 @@ var _ secrets.SecretStore = &smSecretStore{}
 type DefaultSecretStoreProvider struct{}
 
 // NewSecretStore constructs a Vault based secret store with specific secret store spec.
-func (p *DefaultSecretStoreProvider) NewSecretStore(spec v1.SecretStoreSpec) (secrets.SecretStore, error) {
+func (p *DefaultSecretStoreProvider) NewSecretStore(spec v1.SecretStore) (secrets.SecretStore, error) {
 	providerSpec := spec.Provider
 	if providerSpec == nil {
 		return nil, fmt.Errorf(errMissingProviderSpec)
@@ -126,6 +126,8 @@ func (s *smSecretStore) convertSecretToGjson(secretValueOutput *secretsmanager.G
 }
 
 func init() {
+	fmt.Printf("init aws secret")
+
 	secrets.Register(&DefaultSecretStoreProvider{}, &v1.ProviderSpec{
 		AWS: &v1.AWSProvider{},
 	})

--- a/pkg/secrets/providers/aws/secretsmanager/secretsmanager_test.go
+++ b/pkg/secrets/providers/aws/secretsmanager/secretsmanager_test.go
@@ -134,21 +134,21 @@ func TestGetSecret(t *testing.T) {
 
 func TestNewSecretStore(t *testing.T) {
 	testCases := map[string]struct {
-		spec        v1.SecretStoreSpec
+		spec        v1.SecretStore
 		expectedErr error
 	}{
 		"InvalidSecretStoreSpec": {
-			spec:        v1.SecretStoreSpec{},
+			spec:        v1.SecretStore{},
 			expectedErr: errors.New(errMissingProviderSpec),
 		},
 		"InvalidProviderSpec": {
-			spec: v1.SecretStoreSpec{
+			spec: v1.SecretStore{
 				Provider: &v1.ProviderSpec{},
 			},
 			expectedErr: errors.New(errMissingAWSProvider),
 		},
 		"ValidVaultProviderSpec": {
-			spec: v1.SecretStoreSpec{
+			spec: v1.SecretStore{
 				Provider: &v1.ProviderSpec{
 					AWS: &v1.AWSProvider{
 						Region: "us-east-1",

--- a/pkg/secrets/providers/azure/keyvault/keyvault.go
+++ b/pkg/secrets/providers/azure/keyvault/keyvault.go
@@ -38,7 +38,7 @@ var _ secrets.SecretStore = &kvSecretStore{}
 type DefaultSecretStoreProvider struct{}
 
 // NewSecretStore constructs an Azure KeyVault based secret store with specific secret store spec.
-func (p *DefaultSecretStoreProvider) NewSecretStore(spec v1.SecretStoreSpec) (secrets.SecretStore, error) {
+func (p *DefaultSecretStoreProvider) NewSecretStore(spec v1.SecretStore) (secrets.SecretStore, error) {
 	providerSpec := spec.Provider
 	if providerSpec == nil {
 		return nil, fmt.Errorf(errMissingProviderSpec)

--- a/pkg/secrets/providers/azure/keyvault/keyvault_test.go
+++ b/pkg/secrets/providers/azure/keyvault/keyvault_test.go
@@ -100,22 +100,22 @@ func TestGetSecret(t *testing.T) {
 
 func TestNewSecretStore(t *testing.T) {
 	testCases := map[string]struct {
-		spec        v1.SecretStoreSpec
+		spec        v1.SecretStore
 		initEnv     bool
 		expectedErr error
 	}{
 		"InvalidSecretStoreSpec": {
-			spec:        v1.SecretStoreSpec{},
+			spec:        v1.SecretStore{},
 			expectedErr: errors.New(errMissingProviderSpec),
 		},
 		"InvalidProviderSpec": {
-			spec: v1.SecretStoreSpec{
+			spec: v1.SecretStore{
 				Provider: &v1.ProviderSpec{},
 			},
 			expectedErr: errors.New(errMissingAzureProvider),
 		},
 		"InvalidAzureKVProviderSpec": {
-			spec: v1.SecretStoreSpec{
+			spec: v1.SecretStore{
 				Provider: &v1.ProviderSpec{
 					Azure: &v1.AzureKVProvider{
 						VaultURL: &fakeVaultURL,
@@ -125,7 +125,7 @@ func TestNewSecretStore(t *testing.T) {
 			expectedErr: errors.New(errMissingTenant),
 		},
 		"NoClientIDSecretEnvFound": {
-			spec: v1.SecretStoreSpec{
+			spec: v1.SecretStore{
 				Provider: &v1.ProviderSpec{
 					Azure: &v1.AzureKVProvider{
 						VaultURL: &fakeVaultURL,
@@ -136,7 +136,7 @@ func TestNewSecretStore(t *testing.T) {
 			expectedErr: errors.New(errMissingClientIDSecret),
 		},
 		"ValidVaultProviderSpec": {
-			spec: v1.SecretStoreSpec{
+			spec: v1.SecretStore{
 				Provider: &v1.ProviderSpec{
 					Azure: &v1.AzureKVProvider{
 						VaultURL: &fakeVaultURL,

--- a/pkg/secrets/providers/fake/fake.go
+++ b/pkg/secrets/providers/fake/fake.go
@@ -30,7 +30,7 @@ var _ secrets.SecretStore = &fakeSecretStore{}
 type DefaultSecretStoreProvider struct{}
 
 // NewSecretStore constructs a fake secret store instance.
-func (p *DefaultSecretStoreProvider) NewSecretStore(spec v1.SecretStoreSpec) (secrets.SecretStore, error) {
+func (p *DefaultSecretStoreProvider) NewSecretStore(spec v1.SecretStore) (secrets.SecretStore, error) {
 	providerSpec := spec.Provider
 	if providerSpec == nil {
 		return nil, fmt.Errorf(errMissingProviderSpec)

--- a/pkg/secrets/providers/fake/fake_test.go
+++ b/pkg/secrets/providers/fake/fake_test.go
@@ -76,7 +76,7 @@ func TestGetSecret(t *testing.T) {
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			ss, _ := p.NewSecretStore(v1.SecretStoreSpec{
+			ss, _ := p.NewSecretStore(v1.SecretStore{
 				Provider: &v1.ProviderSpec{
 					Fake: &v1.FakeProvider{
 						Data: tt.input,
@@ -98,21 +98,21 @@ func TestGetSecret(t *testing.T) {
 
 func TestNewSecretStore(t *testing.T) {
 	testCases := map[string]struct {
-		spec        v1.SecretStoreSpec
+		spec        v1.SecretStore
 		expectedErr error
 	}{
 		"InvalidSecretStoreSpec": {
-			spec:        v1.SecretStoreSpec{},
+			spec:        v1.SecretStore{},
 			expectedErr: errors.New(errMissingProviderSpec),
 		},
 		"InvalidProviderSpec": {
-			spec: v1.SecretStoreSpec{
+			spec: v1.SecretStore{
 				Provider: &v1.ProviderSpec{},
 			},
 			expectedErr: errors.New(errMissingFakeProvider),
 		},
 		"ValidFakeProviderSpec": {
-			spec: v1.SecretStoreSpec{
+			spec: v1.SecretStore{
 				Provider: &v1.ProviderSpec{
 					Fake: &v1.FakeProvider{},
 				},
@@ -120,7 +120,7 @@ func TestNewSecretStore(t *testing.T) {
 			expectedErr: nil,
 		},
 		"ValidFakeProviderSpec_WithData": {
-			spec: v1.SecretStoreSpec{
+			spec: v1.SecretStore{
 				Provider: &v1.ProviderSpec{
 					Fake: &v1.FakeProvider{
 						Data: []v1.FakeProviderData{

--- a/pkg/secrets/providers/hashivault/vault.go
+++ b/pkg/secrets/providers/hashivault/vault.go
@@ -37,7 +37,7 @@ var _ secrets.SecretStore = &vaultSecretStore{}
 type DefaultSecretStoreProvider struct{}
 
 // NewSecretStore constructs a Vault based secret store with specific secret store spec.
-func (p *DefaultSecretStoreProvider) NewSecretStore(spec v1.SecretStoreSpec) (secrets.SecretStore, error) {
+func (p *DefaultSecretStoreProvider) NewSecretStore(spec v1.SecretStore) (secrets.SecretStore, error) {
 	providerSpec := spec.Provider
 	if providerSpec == nil || providerSpec.Vault == nil {
 		return nil, errors.New(errInvalidVaultSecretStore)

--- a/pkg/secrets/providers/hashivault/vault_test.go
+++ b/pkg/secrets/providers/hashivault/vault_test.go
@@ -262,21 +262,21 @@ func TestBuildPath(t *testing.T) {
 
 func TestNewSecretStore(t *testing.T) {
 	testCases := map[string]struct {
-		spec        v1.SecretStoreSpec
+		spec        v1.SecretStore
 		expectedErr error
 	}{
 		"InvalidSecretStoreSpec": {
-			spec:        v1.SecretStoreSpec{},
+			spec:        v1.SecretStore{},
 			expectedErr: errors.New(errInvalidVaultSecretStore),
 		},
 		"InvalidProviderSpec": {
-			spec: v1.SecretStoreSpec{
+			spec: v1.SecretStore{
 				Provider: &v1.ProviderSpec{},
 			},
 			expectedErr: errors.New(errInvalidVaultSecretStore),
 		},
 		"ValidVaultProviderSpec": {
-			spec: v1.SecretStoreSpec{
+			spec: v1.SecretStore{
 				Provider: &v1.ProviderSpec{
 					Vault: &v1.VaultProvider{
 						Server: "https://127.0.0.1:8200",
@@ -286,7 +286,7 @@ func TestNewSecretStore(t *testing.T) {
 			expectedErr: nil,
 		},
 		"ValidVaultProviderSpec_WithToken": {
-			spec: v1.SecretStoreSpec{
+			spec: v1.SecretStore{
 				Provider: &v1.ProviderSpec{
 					Vault: &v1.VaultProvider{
 						Server: "https://127.0.0.1:8200",

--- a/pkg/secrets/providers_test.go
+++ b/pkg/secrets/providers_test.go
@@ -21,7 +21,7 @@ func (fss *FakeSecretStore) GetSecret(_ context.Context, _ v1.ExternalSecretRef)
 type FakeSecretStoreProvider struct{}
 
 // Fake implementation of SecretStoreProvider.NewSecretStore.
-func (fsf *FakeSecretStoreProvider) NewSecretStore(_ v1.SecretStoreSpec) (SecretStore, error) {
+func (fsf *FakeSecretStoreProvider) NewSecretStore(_ v1.SecretStore) (SecretStore, error) {
 	return &FakeSecretStore{}, nil
 }
 

--- a/pkg/workspace/validation.go
+++ b/pkg/workspace/validation.go
@@ -153,8 +153,8 @@ func ValidateModulePatcherConfigs(config v1.ModulePatcherConfigs) error {
 	return nil
 }
 
-// ValidateSecretStoreConfig tests that the specified SecretStoreSpec has valid data.
-func ValidateSecretStoreConfig(spec *v1.SecretStoreSpec) []error {
+// ValidateSecretStoreConfig tests that the specified SecretStore has valid data.
+func ValidateSecretStoreConfig(spec *v1.SecretStore) []error {
 	if spec.Provider == nil {
 		return []error{ErrMissingProvider}
 	}

--- a/pkg/workspace/validation_test.go
+++ b/pkg/workspace/validation_test.go
@@ -441,7 +441,7 @@ func TestValidateAlicloudSecretStore(t *testing.T) {
 
 func TestValidateSecretStoreConfig(t *testing.T) {
 	type args struct {
-		spec *v1.SecretStoreSpec
+		spec *v1.SecretStore
 	}
 	tests := []struct {
 		name string
@@ -451,14 +451,14 @@ func TestValidateSecretStoreConfig(t *testing.T) {
 		{
 			name: "missing provider spec",
 			args: args{
-				spec: &v1.SecretStoreSpec{},
+				spec: &v1.SecretStore{},
 			},
 			want: []error{ErrMissingProvider},
 		},
 		{
 			name: "missing provider type",
 			args: args{
-				spec: &v1.SecretStoreSpec{
+				spec: &v1.SecretStore{
 					Provider: &v1.ProviderSpec{},
 				},
 			},
@@ -467,7 +467,7 @@ func TestValidateSecretStoreConfig(t *testing.T) {
 		{
 			name: "multi secret store providers",
 			args: args{
-				spec: &v1.SecretStoreSpec{
+				spec: &v1.SecretStore{
 					Provider: &v1.ProviderSpec{
 						AWS: &v1.AWSProvider{
 							Region: "us-east-1",
@@ -483,7 +483,7 @@ func TestValidateSecretStoreConfig(t *testing.T) {
 		{
 			name: "valid secret store spec",
 			args: args{
-				spec: &v1.SecretStoreSpec{
+				spec: &v1.SecretStore{
 					Provider: &v1.ProviderSpec{
 						AWS: &v1.AWSProvider{
 							Region: "us-east-1",


### PR DESCRIPTION
fix: secret store doesn't work

- import the secrets register pkg in the app config generator to register supported secret providers
- rename SecretStoreSpec to SecretStore to prevent misunderstanding of the concept Spec

<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
