### PR TITLE
fix: set the release phase as failed when exit apply prompt

### DIFF
--- a/pkg/cmd/apply/apply.go
+++ b/pkg/cmd/apply/apply.go
@@ -823,7 +823,7 @@ func prompt(ui *terminal.UI) (string, error) {
 		WithDefaultOption("details").
 		// To gracefully exit if interrupted by SIGINT or SIGTERM.
 		WithOnInterruptFunc(func() {
-			release.UpdateReleasePhase(rel, apiv1.ReleasePhaseSucceeded, relLock)
+			release.UpdateReleasePhase(rel, apiv1.ReleasePhaseFailed, relLock)
 			release.UpdateApplyRelease(storage, rel, false, relLock)
 			os.Exit(1)
 		}).


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug
#### What this PR does / why we need it:
This PR sets the release phase as failed when exit the prompt of `kusion apply` due to `SIGINT` or `SIGTERM`. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
