### PR TITLE
fix: watch context timeout and display text for apply

### DIFF
--- a/pkg/cmd/apply/apply.go
+++ b/pkg/cmd/apply/apply.go
@@ -459,7 +459,7 @@ func Apply(
 		// Init a spinner printer for the resource to print the apply status.
 		changesWriterMap[key.ID], err = o.UI.SpinnerPrinter.
 			WithWriter(multi.NewWriter()).
-			Start(fmt.Sprintf("Waiting %s to apply ...", pterm.Bold.Sprint(key.ID)))
+			Start(fmt.Sprintf("Pending %s", pterm.Bold.Sprint(key.ID)))
 		if err != nil {
 			return nil, fmt.Errorf("failed to init change step spinner printer: %v", err)
 		}
@@ -695,8 +695,8 @@ func Watch(
 			// Get the resource ID to be watched.
 			case id := <-ac.WatchCh:
 				res := resourceMap[id]
-				// Set the timeout duration for watch context, here we set an experiential value of 5 minutes.
-				ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(5))
+				// Set the timeout duration for watch context, here we set an experiential value of 60 minutes.
+				ctx, cancel := context.WithTimeout(context.Background(), time.Minute*time.Duration(60))
 				defer cancel()
 
 				// Get the event channel for watching the resource.


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug
#### What this PR does / why we need it:
This PR fixes some bugs of watch context timeout and display text for `kusion apply`. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
