### PR TITLE
fix: skip replacing secret data without ref prefix

### DIFF
--- a/pkg/engine/operation/graph/resource_node.go
+++ b/pkg/engine/operation/graph/resource_node.go
@@ -36,6 +36,10 @@ const (
 	ImplicitRefPrefix = "$kusion_path."
 )
 
+const (
+	SecretRefPrefix = "ref://"
+)
+
 func (rn *ResourceNode) PreExecute(o *models.Operation) v1.Status {
 	value := reflect.ValueOf(rn.resource.Attributes)
 
@@ -87,6 +91,12 @@ func replaceSecretRef(o *models.Operation, obj map[string]interface{}) (map[stri
 	}
 	for k, data := range secret.Data {
 		ref := string(data)
+
+		// Skip the secret data which is not with the secret ref prefix.
+		if !strings.HasPrefix(ref, SecretRefPrefix) {
+			continue
+		}
+
 		externalSecretRef, err := parseExternalSecretDataRef(ref)
 		if err != nil {
 			return nil, v1.NewErrorStatus(err)


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug
#### What this PR does / why we need it:
This PR fixes a bug of replacing secret ref prefix in `kusion apply` command, which skips the secret data without ref prefix. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
