### PR TITLE
feat: add support for on-premises secret provider define in api.kusion.io

### DIFF
--- a/pkg/apis/api.kusion.io/v1/types.go
+++ b/pkg/apis/api.kusion.io/v1/types.go
@@ -721,6 +721,9 @@ type ProviderSpec struct {
 
 	// Fake configures a store with static key/value pairs
 	Fake *FakeProvider `yaml:"fake,omitempty" json:"fake,omitempty"`
+
+	// Onprem configures a store in on-premises environments
+	OnPremises *OnPremisesProvider `yaml:"onpremises,omitempty" json:"onpremises,omitempty"`
 }
 
 // AlicloudProvider configures a store to retrieve secrets from Alicloud Secrets Manager.
@@ -796,6 +799,14 @@ type FakeProviderData struct {
 	Value    string            `json:"value,omitempty"`
 	ValueMap map[string]string `json:"valueMap,omitempty"`
 	Version  string            `json:"version,omitempty"`
+}
+
+// OnPremisesProvider configures a secret provider in on-premises environments
+type OnPremisesProvider struct {
+	// platform name of the provider
+	Name string `json:"name"`
+	// attributes of the provider
+	Attributes map[string]string `json:"attributes,omitempty"`
 }
 
 type Type string

--- a/pkg/secrets/providers.go
+++ b/pkg/secrets/providers.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -85,6 +86,12 @@ func (ps *Providers) getProviderByName(providerName string) (SecretStoreProvider
 }
 
 func getProviderName(spec *v1.ProviderSpec) (string, error) {
+	if spec.OnPremises != nil {
+		if spec.OnPremises.Name == "" {
+			return "", errors.New("on-premises secret stores must have name, found null")
+		}
+		return spec.OnPremises.Name, nil
+	}
 	specBytes, err := json.Marshal(spec)
 	if err != nil || specBytes == nil {
 		return "", fmt.Errorf("failed to marshal secret store provider spec: %w", err)

--- a/pkg/secrets/providers_test.go
+++ b/pkg/secrets/providers_test.go
@@ -47,6 +47,17 @@ func TestRegister(t *testing.T) {
 				AWS: &v1.AWSProvider{},
 			},
 		},
+		{
+			name:         "should register a valid provider",
+			providerName: "customplaform",
+			shouldPanic:  false,
+			expExists:    true,
+			spec: &v1.ProviderSpec{
+				OnPremises: &v1.OnPremisesProvider{
+					Name: "customplaform",
+				},
+			},
+		},
 	}
 
 	fsp := &FakeSecretStoreProvider{}


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind feature

#### What this PR does / why we need it:
Now if I want to add new secret provider in specific scene(some secret provider is only use in some company thus it can not be open source), I need to add new provider spec in apis/api.kusion.io/v1. I think apis/api.kusion.io/v1 should be consistent among different use case
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1177

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
