### PR TITLE
fix: a TF breaking change to enable reusing cached providers

### DIFF
--- a/pkg/engine/runtime/terraform/tfops/workspace.go
+++ b/pkg/engine/runtime/terraform/tfops/workspace.go
@@ -28,20 +28,27 @@ const (
 )
 
 const (
-	envLog            = "TF_LOG"
-	envPluginCacheDir = "TF_PLUGIN_CACHE_DIR"
-	tfDebugLOG        = "DEBUG"
-	envLogPath        = "TF_LOG_PATH"
-	LockHCLFile       = ".terraform.lock.hcl"
-	mainTFFile        = "main.tf.json"
-	tfPlanFile        = "plan.out"
-	tfStateFile       = "terraform.tfstate"
-	tfProviderPrefix  = "terraform-provider"
-	terraformD        = ".terraform.d"
-	pluginCache       = "plugin-cache"
+	envLog = "TF_LOG"
+	// According to this issue(https://github.com/hashicorp/terraform/issues/35345),
+	// the description of `TF_PLUGIN_CACHE_DIR` is out of date and won't work as we expected.
+	// we have to set TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE to ignore the dependency lock file to reuse the plugin cache.
+	envBreakDependencyLockFile = "TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE"
+	envPluginCacheDir          = "TF_PLUGIN_CACHE_DIR"
+	tfDebugLOG                 = "DEBUG"
+	envLogPath                 = "TF_LOG_PATH"
+	LockHCLFile                = ".terraform.lock.hcl"
+	mainTFFile                 = "main.tf.json"
+	tfPlanFile                 = "plan.out"
+	tfStateFile                = "terraform.tfstate"
+	tfProviderPrefix           = "terraform-provider"
+	terraformD                 = ".terraform.d"
+	pluginCache                = "plugin-cache"
 )
 
-var envTFLog = fmt.Sprintf("%s=%s", envLog, tfDebugLOG)
+var (
+	envTFLog                              = fmt.Sprintf("%s=%s", envLog, tfDebugLOG)
+	envPluginCacheBreakDependencyLockFile = fmt.Sprintf("%s=%s", envBreakDependencyLockFile, "true")
+)
 
 type WorkSpace struct {
 	resource   *v1.Resource
@@ -230,7 +237,7 @@ func (w *WorkSpace) initEnvs() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	result := append(os.Environ(), envTFLog, providerCachePath, logPath)
+	result := append(os.Environ(), envTFLog, envPluginCacheBreakDependencyLockFile, providerCachePath, logPath)
 	return result, nil
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1196 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
