### PR TITLE
fix: deep copy resource attributes

### DIFF
--- a/pkg/util/diff/diff.go
+++ b/pkg/util/diff/diff.go
@@ -2,6 +2,7 @@ package diff
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 
 	"github.com/gonvenience/wrap"
@@ -141,7 +142,7 @@ func maskSensitiveData(oldData, newData interface{}) (interface{}, interface{}) 
 			if from.Type == v1.Kubernetes && ok && fromKind == "Secret" {
 				// Set masking old data to true.
 				maskOld = true
-				*maskedOldData = *from
+				deepCopyResource(from, maskedOldData)
 
 				// Append 'data' and 'stringData' attributes of the old secret resource.
 				if _, ok := from.Attributes["data"]; ok {
@@ -173,7 +174,7 @@ func maskSensitiveData(oldData, newData interface{}) (interface{}, interface{}) 
 			if to.Type == v1.Kubernetes && ok && toKind == "Secret" {
 				// Set masking new data to true.
 				maskNew = true
-				*maskedNewData = *to
+				deepCopyResource(to, maskedNewData)
 
 				// Append 'data' and 'stringData' attributes of the new secret resource.
 				if _, ok := to.Attributes["data"]; ok {
@@ -267,4 +268,48 @@ func maskSensitiveData(oldData, newData interface{}) (interface{}, interface{}) 
 	}
 
 	return maskedOldData, maskedNewData
+}
+
+// deepCopyResource deeply copies the old Resource into a new one.
+func deepCopyResource(from, to *v1.Resource) error {
+	to.ID = from.ID
+	to.Type = from.Type
+
+	var err error
+	if len(from.Attributes) != 0 {
+		if to.Attributes, err = deepCopyMap(from.Attributes); err != nil {
+			return err
+		}
+	}
+
+	if len(from.Extensions) != 0 {
+		if to.Extensions, err = deepCopyMap(from.Extensions); err != nil {
+			return err
+		}
+	}
+
+	if len(from.DependsOn) != 0 {
+		if len(to.DependsOn) == 0 {
+			to.DependsOn = make([]string, len(from.DependsOn))
+		}
+		for i, v := range from.DependsOn {
+			to.DependsOn[i] = v
+		}
+	}
+
+	return nil
+}
+
+func deepCopyMap(src map[string]interface{}) (map[string]interface{}, error) {
+	jsonBytes, err := json.Marshal(src)
+	if err != nil {
+		return nil, err
+	}
+
+	var dest map[string]interface{}
+	if err = json.Unmarshal(jsonBytes, &dest); err != nil {
+		return nil, err
+	}
+
+	return dest, nil
 }

--- a/pkg/util/diff/diff.go
+++ b/pkg/util/diff/diff.go
@@ -292,14 +292,13 @@ func deepCopyResource(from, to *v1.Resource) error {
 		if len(to.DependsOn) == 0 {
 			to.DependsOn = make([]string, len(from.DependsOn))
 		}
-		for i, v := range from.DependsOn {
-			to.DependsOn[i] = v
-		}
+		copy(to.DependsOn, from.DependsOn)
 	}
 
 	return nil
 }
 
+// deepCopyMap deeply copies the map[string]interface{}.
 func deepCopyMap(src map[string]interface{}) (map[string]interface{}, error) {
 	jsonBytes, err := json.Marshal(src)
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug
#### What this PR does / why we need it:
This PR fixes a bug of deep copying resource attributes when getting the diff report. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
