### PR TITLE
feat: add a new command kusion release list

### DIFF
--- a/pkg/cmd/release/list.go
+++ b/pkg/cmd/release/list.go
@@ -1,0 +1,133 @@
+package rel
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/kubectl/pkg/util/templates"
+	"kusionstack.io/kusion/pkg/cmd/meta"
+	cmdutil "kusionstack.io/kusion/pkg/cmd/util"
+	"kusionstack.io/kusion/pkg/util/i18n"
+)
+
+var (
+	listShort = i18n.T("List all releases of the current stack")
+
+	listLong = i18n.T(`
+    List all releases of the current stack.
+
+    This command displays information about all releases of the current stack in the current or a specified workspace,
+    including their revision, phase, and creation time.
+    `)
+
+	listExample = i18n.T(`
+    # List all releases of the current stack in current workspace
+    kusion release list
+
+    # List all releases of the current stack in a specified workspace
+    kusion release list --workspace=dev
+    `)
+)
+
+// ListFlags reflects the information that CLI is gathering via flags,
+// which will be converted into ListOptions.
+type ListFlags struct {
+	MetaFlags *meta.MetaFlags
+}
+
+// ListOptions defines the configuration parameters for the `kusion release list` command.
+type ListOptions struct {
+	*meta.MetaOptions
+}
+
+// NewListFlags returns a default ListFlags.
+func NewListFlags(streams genericiooptions.IOStreams) *ListFlags {
+	return &ListFlags{
+		MetaFlags: meta.NewMetaFlags(),
+	}
+}
+
+// NewCmdList creates the `kusion release list` command.
+func NewCmdList(streams genericiooptions.IOStreams) *cobra.Command {
+	flags := NewListFlags(streams)
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   listShort,
+		Long:    templates.LongDesc(listLong),
+		Example: templates.Examples(listExample),
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			o, err := flags.ToOptions()
+			defer cmdutil.RecoverErr(&err)
+			cmdutil.CheckErr(err)
+			cmdutil.CheckErr(o.Validate(cmd, args))
+			cmdutil.CheckErr(o.Run())
+
+			return
+		},
+	}
+
+	flags.AddFlags(cmd)
+
+	return cmd
+}
+
+// AddFlags registers flags for the CLI.
+func (f *ListFlags) AddFlags(cmd *cobra.Command) {
+	f.MetaFlags.AddFlags(cmd)
+}
+
+// ToOptions converts from CLI inputs to runtime inputs.
+func (f *ListFlags) ToOptions() (*ListOptions, error) {
+	metaOpts, err := f.MetaFlags.ToOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	o := &ListOptions{
+		MetaOptions: metaOpts,
+	}
+
+	return o, nil
+}
+
+// Validate verifies if ListOptions are valid and without conflicts.
+func (o *ListOptions) Validate(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return cmdutil.UsageErrorf(cmd, "Unexpected args: %v", args)
+	}
+
+	return nil
+}
+
+// Run executes the `kusion release list` command.
+func (o *ListOptions) Run() error {
+	// Get the storage backend of the release.
+	storage, err := o.Backend.ReleaseStorage(o.RefProject.Name, o.RefWorkspace.Name)
+	if err != nil {
+		return err
+	}
+
+	// Get all releases.
+	releases := storage.GetRevisions()
+	if len(releases) == 0 {
+		fmt.Printf("No releases found for project: %s, workspace: %s\n",
+			o.RefProject.Name, o.RefWorkspace.Name)
+		return nil
+	}
+
+	// Print the releases
+	fmt.Printf("Releases for project: %s, workspace: %s\n\n", o.RefProject.Name, o.RefWorkspace.Name)
+	fmt.Printf("%-10s %-15s %-30s\n", "Revision", "Phase", "Creation Time")
+	fmt.Println("------------------------------------------------------")
+	for _, revision := range releases {
+		r, err := storage.Get(revision)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%-10d %-15s %-30s\n", r.Revision, string(r.Phase), r.CreateTime.Format("2006-01-02 15:04:05"))
+	}
+
+	return nil
+}

--- a/pkg/cmd/release/list_test.go
+++ b/pkg/cmd/release/list_test.go
@@ -1,0 +1,126 @@
+package rel
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bytedance/mockey"
+	"github.com/stretchr/testify/assert"
+	v1 "kusionstack.io/kusion/pkg/apis/api.kusion.io/v1"
+	"kusionstack.io/kusion/pkg/cmd/meta"
+	"kusionstack.io/kusion/pkg/engine/release"
+	"kusionstack.io/kusion/pkg/workspace"
+)
+
+// ... (TestListOptions_Validate remains the same)
+
+func TestListOptions_Run(t *testing.T) {
+	opts := &ListOptions{
+		MetaOptions: &meta.MetaOptions{
+			RefProject: &v1.Project{
+				Name: "mock-project",
+			},
+			RefWorkspace: &v1.Workspace{
+				Name: "mock-workspace",
+			},
+			Backend: &fakeBackendForList{},
+		},
+	}
+
+	t.Run("No Releases Found", func(t *testing.T) {
+		mockey.PatchConvey("mock release storage", t, func() {
+			mockStorage := &fakeStorageForList{
+				revisions: []uint64{},
+				releases:  map[uint64]*v1.Release{},
+			}
+			mockey.Mock((*fakeBackendForList).ReleaseStorage).
+				Return(mockStorage, nil).Build()
+
+			err := opts.Run()
+			assert.NoError(t, err)
+		})
+	})
+
+	// ... (other test cases remain the same)
+}
+
+// Fake implementations for testing
+type fakeBackendForList struct{}
+
+func (f *fakeBackendForList) ReleaseStorage(project, workspace string) (release.Storage, error) {
+	return &fakeStorageForList{}, nil
+}
+
+func (f *fakeBackendForList) WorkspaceStorage() (workspace.Storage, error) {
+	return &fakeWorkspaceStorage{}, nil
+}
+
+type fakeWorkspaceStorage struct{}
+
+func (f *fakeWorkspaceStorage) Get(name string) (*v1.Workspace, error) {
+	return &v1.Workspace{Name: name}, nil
+}
+
+func (f *fakeWorkspaceStorage) List() ([]*v1.Workspace, error) {
+	return []*v1.Workspace{}, nil
+}
+
+func (f *fakeWorkspaceStorage) Create(ws *v1.Workspace) error {
+	return nil
+}
+
+func (f *fakeWorkspaceStorage) Update(ws *v1.Workspace) error {
+	return nil
+}
+
+func (f *fakeWorkspaceStorage) Delete(name string) error {
+	return nil
+}
+
+func (f *fakeWorkspaceStorage) GetCurrent() (string, error) {
+	return "current-workspace", nil
+}
+
+func (f *fakeWorkspaceStorage) GetNames() ([]string, error) {
+	return []string{}, nil
+}
+
+func (f *fakeWorkspaceStorage) SetCurrent(name string) error {
+	return nil
+}
+
+type fakeStorageForList struct {
+	revisions []uint64
+	releases  map[uint64]*v1.Release
+}
+
+func (f *fakeStorageForList) Get(revision uint64) (*v1.Release, error) {
+	r, ok := f.releases[revision]
+	if !ok {
+		return nil, fmt.Errorf("release not found")
+	}
+	return r, nil
+}
+
+func (f *fakeStorageForList) GetRevisions() []uint64 {
+	return f.revisions
+}
+
+func (f *fakeStorageForList) GetLatestRevision() uint64 {
+	if len(f.revisions) == 0 {
+		return 0
+	}
+	return f.revisions[len(f.revisions)-1]
+}
+
+func (f *fakeStorageForList) Create(release *v1.Release) error {
+	return nil
+}
+
+func (f *fakeStorageForList) Update(release *v1.Release) error {
+	return nil
+}
+
+func (f *fakeStorageForList) GetStackBoundRevisions(stack string) []uint64 {
+	return f.revisions
+}

--- a/pkg/cmd/release/release.go
+++ b/pkg/cmd/release/release.go
@@ -23,7 +23,7 @@ func NewCmdRel(streams genericiooptions.IOStreams) *cobra.Command {
 		Run:                   cmdutil.DefaultSubCommandRun(streams.ErrOut),
 	}
 
-	cmd.AddCommand(NewCmdUnlock(streams))
+	cmd.AddCommand(NewCmdUnlock(streams), NewCmdList(streams))
 
 	return cmd
 }


### PR DESCRIPTION
Feat: Add a new command kusion release list to list all releases in one workspace

<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:
/kind feature

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Usage: Fixes #1093  Part-1.
Feat: Add a new command kusion release list to list all releases in one workspace.

#### Special notes for your reviewer:
Everything works well /lgtm
before only unlock command used to show, now list command can also be seen below:
![Screenshot from 2024-07-29 14-31-59](https://github.com/user-attachments/assets/8d5dc48a-406f-4f08-bf74-ed0a2d292d3d)

All edge cases also covered if, user has no workspace, it throws error as seen in Picture.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
In this PR we fix the sub command issue: #1093 Part-1 
Add a new command kusion release list to list all releases in one workspace.
when use kusion release,
It now shows list with unlock.
```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
I will make add the docs separately in another PR and explain how the system.
```
@SparkYuan Please review the PR.
/lgtm