### PR TITLE
feat: remove requirement to use imported resource when apply

### DIFF
--- a/pkg/modules/generators/app_configurations_generator.go
+++ b/pkg/modules/generators/app_configurations_generator.go
@@ -663,8 +663,8 @@ func patchImportedResources(resources v1.Resources, projectImportedResources map
 	for kusionID, importedID := range projectImportedResources {
 		if res, ok := resIndex[kusionID]; ok {
 			res.Extensions[tfops.ImportIDKey] = importedID
-		} else {
-			return fmt.Errorf("empty kusion id: %s", kusionID)
+			// remove the resource attribute to avoid update conflict when using terraform import
+			res.Attributes = make(map[string]interface{})
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?
- Currently, when we add a resource to the workspace with importedResources, every time we kusion apply a project in that workspace, we will be required to use that or every imported resources. This will cause some projects that do not use imported resources to be unable to apply.
- One more problem is when applying, the terraform resource that was declared in the workspace, in the phase generate from .k to spec the attributes of it will still receive data by kusion catalog so when we import, the action of it becomes Update not UnChanged. So the resource will update unnecessary fields.

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

-->
/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1259 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
