### PR TITLE
fix: json patch allows empty path on add and remove

### DIFF
--- a/pkg/modules/generators/app_configurations_generator.go
+++ b/pkg/modules/generators/app_configurations_generator.go
@@ -232,7 +232,13 @@ func JSONPatch(resources v1.Resources, patcher *v1.Patcher) error {
 					return fmt.Errorf("decode json patch:%s failed with error %w", jsonPatcher.Payload, err)
 				}
 
-				modified, err := patch.Apply([]byte(target))
+				// Apply JSON Patch with options to allow missing path on `remove`,
+				// and ensure path exists on `add`.
+				applyOpts := jsonpatch.NewApplyOptions()
+				applyOpts.AllowMissingPathOnRemove = true
+				applyOpts.EnsurePathExistsOnAdd = true
+
+				modified, err := patch.ApplyWithOptions([]byte(target), applyOpts)
 				if err != nil {
 					return fmt.Errorf("apply json patch to:%s failed with error %w", id, err)
 				}


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug
#### What this PR does / why we need it:
This PR allows missing path on `remove`, and ensures path exists on `add` operations for JSON Patch. 
Ref: https://github.com/evanphx/json-patch/issues/138
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1249 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
