### PR TITLE
fix: init runtime with state

### DIFF
--- a/pkg/cmd/apply/apply.go
+++ b/pkg/cmd/apply/apply.go
@@ -725,7 +725,7 @@ func Watch(
 			watchErrCh <- *err
 		}()
 		// Init the runtimes according to the resource types.
-		runtimes, s := runtimeinit.Runtimes(*rel.Spec)
+		runtimes, s := runtimeinit.Runtimes(*rel.Spec, *rel.State)
 		if v1.IsErr(s) {
 			panic(fmt.Errorf("failed to init runtimes: %s", s.String()))
 		}

--- a/pkg/engine/operation/apply.go
+++ b/pkg/engine/operation/apply.go
@@ -71,7 +71,7 @@ func (ao *ApplyOperation) Apply(req *ApplyRequest) (rsp *ApplyResponse, s v1.Sta
 		stateResourceIndex[k] = v
 	}
 
-	runtimesMap, s := runtimeinit.Runtimes(*req.Release.Spec)
+	runtimesMap, s := runtimeinit.Runtimes(*req.Release.Spec, *req.Release.State)
 	if v1.IsErr(s) {
 		return nil, s
 	}

--- a/pkg/engine/operation/apply_test.go
+++ b/pkg/engine/operation/apply_test.go
@@ -152,7 +152,7 @@ func TestApplyOperation_Apply(t *testing.T) {
 				return nil
 			}).Build()
 			mockey.Mock(runtimeinit.Runtimes).To(func(
-				spec apiv1.Spec,
+				spec apiv1.Spec, state apiv1.State,
 			) (map[apiv1.Type]runtime.Runtime, v1.Status) {
 				return map[apiv1.Type]runtime.Runtime{runtime.Kubernetes: &kubernetes.KubernetesRuntime{}}, nil
 			}).Build()

--- a/pkg/engine/operation/destroy.go
+++ b/pkg/engine/operation/destroy.go
@@ -48,7 +48,7 @@ func (do *DestroyOperation) Destroy(req *DestroyRequest) (rsp *DestroyResponse, 
 
 	// only destroy resources we have recorded
 	resources := priorState.Resources
-	runtimesMap, s := runtimeinit.Runtimes(*req.Release.Spec)
+	runtimesMap, s := runtimeinit.Runtimes(*req.Release.Spec, *req.Release.State)
 	if v1.IsErr(s) {
 		return nil, s
 	}

--- a/pkg/engine/operation/preview.go
+++ b/pkg/engine/operation/preview.go
@@ -58,7 +58,7 @@ func (po *PreviewOperation) Preview(req *PreviewRequest) (rsp *PreviewResponse, 
 	priorState := req.State
 
 	// Kusion is a multi-runtime system. We initialize runtimes dynamically by resource types
-	runtimesMap, s := runtimeinit.Runtimes(*req.Spec)
+	runtimesMap, s := runtimeinit.Runtimes(*req.Spec, *req.State)
 	if v1.IsErr(s) {
 		return nil, s
 	}

--- a/pkg/engine/operation/preview_test.go
+++ b/pkg/engine/operation/preview_test.go
@@ -253,7 +253,7 @@ func TestPreviewOperation_Preview(t *testing.T) {
 			}
 
 			mockey.Mock(runtimeinit.Runtimes).To(func(
-				spec apiv1.Spec,
+				spec apiv1.Spec, state apiv1.State,
 			) (map[apiv1.Type]runtime.Runtime, v1.Status) {
 				return map[apiv1.Type]runtime.Runtime{runtime.Kubernetes: &fakePreviewRuntime{}}, nil
 			}).Build()

--- a/pkg/engine/operation/watch.go
+++ b/pkg/engine/operation/watch.go
@@ -43,7 +43,7 @@ func (wo *WatchOperation) Watch(req *WatchRequest) error {
 
 	// init runtimes
 	resources := req.Spec.Resources
-	runtimes, s := runtimeinit.Runtimes(*req.Spec)
+	runtimes, s := runtimeinit.Runtimes(*req.Spec, apiv1.State{})
 	if v1.IsErr(s) {
 		return errors.New(s.Message())
 	}

--- a/pkg/engine/operation/watch_test.go
+++ b/pkg/engine/operation/watch_test.go
@@ -94,7 +94,7 @@ func TestWatchOperation_Watch(t *testing.T) {
 			},
 		}
 		mockey.Mock(runtimeinit.Runtimes).To(func(
-			spec apiv1.Spec,
+			spec apiv1.Spec, state apiv1.State,
 		) (map[apiv1.Type]runtime.Runtime, v1.Status) {
 			return map[apiv1.Type]runtime.Runtime{runtime.Kubernetes: fooRuntime}, nil
 		}).Build()

--- a/pkg/engine/runtime/init/init.go
+++ b/pkg/engine/runtime/init/init.go
@@ -34,12 +34,12 @@ var contextKeys = []string{
 // InitFn runtime init func
 type InitFn func(spec apiv1.Spec) (runtime.Runtime, error)
 
-func Runtimes(spec apiv1.Spec) (map[apiv1.Type]runtime.Runtime, v1.Status) {
+func Runtimes(spec apiv1.Spec, state apiv1.State) (map[apiv1.Type]runtime.Runtime, v1.Status) {
 	// Parse the secret ref in the Context of Spec.
 	if err := parseContextSecretRef(&spec); err != nil {
 		return nil, v1.NewErrorStatus(err)
 	}
-	resources := spec.Resources
+	resources := append(spec.Resources, state.Resources...)
 	runtimesMap := map[apiv1.Type]runtime.Runtime{}
 	if resources == nil {
 		return runtimesMap, nil

--- a/pkg/engine/runtime/init/init.go
+++ b/pkg/engine/runtime/init/init.go
@@ -39,7 +39,8 @@ func Runtimes(spec apiv1.Spec, state apiv1.State) (map[apiv1.Type]runtime.Runtim
 	if err := parseContextSecretRef(&spec); err != nil {
 		return nil, v1.NewErrorStatus(err)
 	}
-	resources := append(spec.Resources, state.Resources...)
+	resources := spec.Resources
+	resources = append(resources, state.Resources...)
 	runtimesMap := map[apiv1.Type]runtime.Runtime{}
 	if resources == nil {
 		return runtimesMap, nil


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind bug
#### What this PR does / why we need it:
This PR fixes a bug of initializing Kusion's runtimes with `release.State` as input. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1287 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
