### PR TITLE
feat: support max number of concurrent resource operation executions

### DIFF
--- a/pkg/apis/api.kusion.io/v1/types.go
+++ b/pkg/apis/api.kusion.io/v1/types.go
@@ -734,3 +734,13 @@ type Release struct {
 	// ModifiedTime is the time that the Release is modified.
 	ModifiedTime time.Time `yaml:"modifiedTime" json:"modifiedTime"`
 }
+
+const (
+	// Environment variable for maximum number of concurrent resource executions,
+	// including preview, apply and destroy.
+	// Note that the maximum number should be between 1 to 100.
+	MaxConcurrentEnvVar = "KUSION_EXEC_MAX_CONCURRENT"
+
+	// The default maximum number of concurrent resource executions for Kusion is 10.
+	DefaultMaxConcurrent = 10
+)

--- a/pkg/engine/operation/apply.go
+++ b/pkg/engine/operation/apply.go
@@ -63,7 +63,7 @@ func (ao *ApplyOperation) Apply(req *ApplyRequest) (rsp *ApplyResponse, s v1.Sta
 	}
 
 	// Update the operation semaphore.
-	if err := o.UpdateReleaseState(); err != nil {
+	if err := o.UpdateSemaphore(); err != nil {
 		return nil, v1.NewErrorStatus(err)
 	}
 

--- a/pkg/engine/operation/apply.go
+++ b/pkg/engine/operation/apply.go
@@ -62,6 +62,11 @@ func (ao *ApplyOperation) Apply(req *ApplyRequest) (rsp *ApplyResponse, s v1.Sta
 		return nil, s
 	}
 
+	// Update the operation semaphore.
+	if err := o.UpdateReleaseState(); err != nil {
+		return nil, v1.NewErrorStatus(err)
+	}
+
 	// 1. init & build Indexes
 	priorState := req.Release.State
 	priorStateResourceIndex := priorState.Resources.Index()

--- a/pkg/engine/operation/apply_test.go
+++ b/pkg/engine/operation/apply_test.go
@@ -17,7 +17,6 @@ import (
 	"kusionstack.io/kusion/pkg/engine/runtime"
 	runtimeinit "kusionstack.io/kusion/pkg/engine/runtime/init"
 	"kusionstack.io/kusion/pkg/engine/runtime/kubernetes"
-	"kusionstack.io/kusion/pkg/infra/util/semaphore"
 )
 
 func TestApplyOperation_Apply(t *testing.T) {
@@ -33,7 +32,6 @@ func TestApplyOperation_Apply(t *testing.T) {
 		msgCh                   chan models.Message
 		release                 *apiv1.Release
 		lock                    *sync.Mutex
-		sem                     *semaphore.Semaphore
 	}
 	type args struct {
 		applyRequest *ApplyRequest
@@ -113,7 +111,6 @@ func TestApplyOperation_Apply(t *testing.T) {
 				releaseStorage: &storages.LocalStorage{},
 				runtimeMap:     map[apiv1.Type]runtime.Runtime{runtime.Kubernetes: &kubernetes.KubernetesRuntime{}},
 				msgCh:          make(chan models.Message, 5),
-				sem:            semaphore.New(10),
 			},
 			args: args{applyRequest: &ApplyRequest{
 				Request: models.Request{
@@ -141,7 +138,6 @@ func TestApplyOperation_Apply(t *testing.T) {
 				MsgCh:                   tc.fields.msgCh,
 				Release:                 tc.fields.release,
 				Lock:                    tc.fields.lock,
-				Sem:                     tc.fields.sem,
 			}
 			ao := &ApplyOperation{
 				Operation: *o,

--- a/pkg/engine/operation/destroy.go
+++ b/pkg/engine/operation/destroy.go
@@ -37,6 +37,11 @@ func (do *DestroyOperation) Destroy(req *DestroyRequest) (rsp *DestroyResponse, 
 		return nil, s
 	}
 
+	// Update the operation semaphore.
+	if err := o.UpdateReleaseState(); err != nil {
+		return nil, v1.NewErrorStatus(err)
+	}
+
 	// 1. init & build Indexes
 	priorState := req.Release.State
 	priorStateResourceIndex := priorState.Resources.Index()

--- a/pkg/engine/operation/destroy.go
+++ b/pkg/engine/operation/destroy.go
@@ -38,7 +38,7 @@ func (do *DestroyOperation) Destroy(req *DestroyRequest) (rsp *DestroyResponse, 
 	}
 
 	// Update the operation semaphore.
-	if err := o.UpdateReleaseState(); err != nil {
+	if err := o.UpdateSemaphore(); err != nil {
 		return nil, v1.NewErrorStatus(err)
 	}
 

--- a/pkg/engine/operation/models/operation_context_test.go
+++ b/pkg/engine/operation/models/operation_context_test.go
@@ -1,0 +1,65 @@
+package models
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "kusionstack.io/kusion/pkg/apis/api.kusion.io/v1"
+	"kusionstack.io/kusion/pkg/infra/util/semaphore"
+)
+
+func TestOperation_UpdateSemaphore(t *testing.T) {
+	original := os.Getenv(apiv1.MaxConcurrentEnvVar)
+	defer os.Setenv(apiv1.MaxConcurrentEnvVar, original)
+
+	testcases := []struct {
+		name        string
+		env         string
+		expectedErr error
+		expectedVal int64
+	}{
+		{
+			name:        "Invalid Env Type",
+			env:         "not-a-number",
+			expectedErr: errors.New("invalid syntax"),
+		},
+		{
+			name:        "Invalid Value (less than 0)",
+			env:         "-1",
+			expectedErr: errors.New("invalid value"),
+		},
+		{
+			name:        "Invalid Value (larger than 100)",
+			env:         "200",
+			expectedErr: errors.New("invalid value"),
+		},
+		{
+			name:        "Default Value",
+			env:         "",
+			expectedErr: nil,
+			expectedVal: int64(apiv1.DefaultMaxConcurrent),
+		},
+		{
+			name:        "Customized Value",
+			env:         "50",
+			expectedErr: nil,
+			expectedVal: int64(50),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			op := &Operation{}
+			os.Setenv(apiv1.MaxConcurrentEnvVar, tc.env)
+			err := op.UpdateSemaphore()
+			if tc.expectedErr != nil {
+				assert.ErrorContains(t, err, tc.expectedErr.Error())
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, *semaphore.New(tc.expectedVal), *op.Sem)
+			}
+		})
+	}
+}

--- a/pkg/engine/operation/preview.go
+++ b/pkg/engine/operation/preview.go
@@ -55,7 +55,7 @@ func (po *PreviewOperation) Preview(req *PreviewRequest) (rsp *PreviewResponse, 
 	}
 
 	// Update the operation semaphore.
-	if err := o.UpdateReleaseState(); err != nil {
+	if err := o.UpdateSemaphore(); err != nil {
 		return nil, v1.NewErrorStatus(err)
 	}
 

--- a/pkg/engine/operation/preview.go
+++ b/pkg/engine/operation/preview.go
@@ -54,6 +54,11 @@ func (po *PreviewOperation) Preview(req *PreviewRequest) (rsp *PreviewResponse, 
 		return nil, s
 	}
 
+	// Update the operation semaphore.
+	if err := o.UpdateReleaseState(); err != nil {
+		return nil, v1.NewErrorStatus(err)
+	}
+
 	// 1. init & build Indexes
 	priorState := req.State
 


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind feature
#### What this PR does / why we need it:
This PR adds support for maximum number of concurrent resource operation executions. Users can set the value with the `KUSION_EXEC_MAX_CONCURRENT` environment variable, which defaults to `10`. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1198 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
