### PR TITLE
feat: support watch in runs

### DIFF
--- a/pkg/engine/api/apply.go
+++ b/pkg/engine/api/apply.go
@@ -1,22 +1,46 @@
 package api
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"reflect"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/liu-hm19/pterm"
+	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/watch"
 
 	apiv1 "kusionstack.io/kusion/pkg/apis/api.kusion.io/v1"
 	v1 "kusionstack.io/kusion/pkg/apis/status/v1"
+	cmdutil "kusionstack.io/kusion/pkg/cmd/util"
+	"kusionstack.io/kusion/pkg/engine"
 	"kusionstack.io/kusion/pkg/engine/operation"
 	"kusionstack.io/kusion/pkg/engine/operation/models"
+	"kusionstack.io/kusion/pkg/engine/printers"
 	"kusionstack.io/kusion/pkg/engine/release"
+	"kusionstack.io/kusion/pkg/engine/resource/graph"
+	"kusionstack.io/kusion/pkg/engine/runtime"
+	runtimeinit "kusionstack.io/kusion/pkg/engine/runtime/init"
 	"kusionstack.io/kusion/pkg/infra/util/semaphore"
 	"kusionstack.io/kusion/pkg/log"
 	logutil "kusionstack.io/kusion/pkg/server/util/logging"
+	"kusionstack.io/kusion/pkg/util/kcl"
+	"kusionstack.io/kusion/pkg/util/pretty"
+)
+
+// To handle the release phase update when panic occurs.
+// Fixme: adopt a more centralized approach to manage the release update before exiting, instead of
+// scattering them across different go-routines.
+var (
+	relLock        = &sync.Mutex{}
+	releaseCreated = false
+	releaseStorage release.Storage
 )
 
 // The Apply function will apply the resources changes
@@ -35,6 +59,8 @@ func Apply(
 	out io.Writer,
 ) (*apiv1.Release, error) {
 	logger := logutil.GetLogger(ctx)
+	var err error
+
 	// construct the apply operation
 	ac := &operation.ApplyOperation{
 		Operation: models.Operation{
@@ -46,8 +72,33 @@ func Apply(
 		},
 	}
 
+	// Init a watch channel with a sufficient buffer when it is necessary to perform watching.
+	if o.Watch && !o.DryRun {
+		ac.WatchCh = make(chan string, 100)
+	}
+
 	// line summary
 	var ls lineSummary
+	// Get the multi printer from UI option.
+	multi := o.UI.MultiPrinter
+	// Max length of resource ID for progressbar width.
+	maxLen := 0
+
+	// Prepare the writer to print the operation progress and results.
+	changesWriterMap := make(map[string]*pterm.SpinnerPrinter)
+	for _, key := range changes.Values() {
+		// Get the maximum length of the resource ID.
+		if len(key.ID) > maxLen {
+			maxLen = len(key.ID)
+		}
+		// Init a spinner printer for the resource to print the apply status.
+		changesWriterMap[key.ID], err = o.UI.SpinnerPrinter.
+			WithWriter(multi.NewWriter()).
+			Start(fmt.Sprintf("Pending %s", pterm.Bold.Sprint(key.ID)))
+		if err != nil {
+			return nil, fmt.Errorf("failed to init change step spinner printer: %v", err)
+		}
+	}
 
 	// progress bar, print dag walk detail
 	progressbar, err := pterm.DefaultProgressbar.
@@ -59,64 +110,50 @@ func Apply(
 	if err != nil {
 		return nil, err
 	}
+
+	// The writer below is for operation error printing.
+	errWriter := multi.NewWriter()
+
+	multi.WithUpdateDelay(time.Millisecond * 100)
+	multi.Start()
+	defer multi.Stop()
+
 	// wait msgCh close
 	var wg sync.WaitGroup
 	// receive msg and print detail
-	go func() {
-		defer func() {
-			if p := recover(); p != nil {
-				log.Errorf("failed to receive msg and print detail as %v", p)
-			}
-		}()
-		wg.Add(1)
+	go PrintApplyDetails(
+		ac,
+		&err,
+		&errWriter,
+		&wg,
+		changes,
+		changesWriterMap,
+		progressbar,
+		&ls,
+		o.DryRun,
+		o.Watch,
+		gph.Resources,
+		gph,
+		rel,
+	)
 
-		for {
-			select {
-			case msg, ok := <-ac.MsgCh:
-				if !ok {
-					wg.Done()
-					return
-				}
-				changeStep := changes.Get(msg.ResourceID)
-
-				switch msg.OpResult {
-				case models.Success, models.Skip:
-					var title string
-					if changeStep.Action == models.UnChanged {
-						title = fmt.Sprintf("%s %s, %s",
-							changeStep.Action.String(),
-							pterm.Bold.Sprint(changeStep.ID),
-							strings.ToLower(string(models.Skip)),
-						)
-					} else {
-						title = fmt.Sprintf("%s %s %s",
-							changeStep.Action.String(),
-							pterm.Bold.Sprint(changeStep.ID),
-							strings.ToLower(string(msg.OpResult)),
-						)
-					}
-					pterm.Success.WithWriter(out).Println(title)
-					progressbar.UpdateTitle(title)
-					progressbar.Increment()
-					ls.Count(changeStep.Action)
-				case models.Failed:
-					title := fmt.Sprintf("%s %s %s",
-						changeStep.Action.String(),
-						pterm.Bold.Sprint(changeStep.ID),
-						strings.ToLower(string(msg.OpResult)),
-					)
-					pterm.Error.WithWriter(out).Printf("%s\n", title)
-				default:
-					title := fmt.Sprintf("%s %s %s",
-						changeStep.Action.Ing(),
-						pterm.Bold.Sprint(changeStep.ID),
-						strings.ToLower(string(msg.OpResult)),
-					)
-					progressbar.UpdateTitle(title)
-				}
-			}
-		}
-	}()
+	watchErrCh := make(chan error)
+	// Apply while watching the resources.
+	if o.Watch && !o.DryRun {
+		logger.Info("Start watching resources ...")
+		Watch(
+			ac,
+			changes,
+			&err,
+			o.DryRun,
+			watchErrCh,
+			multi,
+			changesWriterMap,
+			gph,
+			rel,
+		)
+		logger.Info("Watch completed ...")
+	}
 
 	var upRel *apiv1.Release
 	if o.DryRun {
@@ -146,6 +183,22 @@ func Apply(
 
 	// wait for msgCh closed
 	wg.Wait()
+	// Wait for watchWg closed if need to perform watching.
+	if o.Watch && !o.DryRun {
+		shouldBreak := false
+		for !shouldBreak {
+			select {
+			case watchErr := <-watchErrCh:
+				if watchErr != nil {
+					return nil, watchErr
+				}
+				shouldBreak = true
+			default:
+				continue
+			}
+		}
+	}
+
 	// print summary
 	logger.Info(fmt.Sprintf("Apply complete! Resources: %d created, %d updated, %d deleted.", ls.created, ls.updated, ls.deleted))
 	return upRel, nil
@@ -166,38 +219,135 @@ func Apply(
 //	if err != nil {
 //	    return err
 //	}
+//
+// Watch function will watch the changed Kubernetes and Terraform resources.
+// Fixme: abstract the input variables into a struct.
 func Watch(
-	o *APIOptions,
-	planResources *apiv1.Spec,
+	ac *operation.ApplyOperation,
 	changes *models.Changes,
-) error {
-	if o.DryRun {
-		fmt.Println("NOTE: Watch doesn't work in DryRun mode")
-		return nil
-	}
-
-	// filter out unchanged resources
+	err *error,
+	dryRun bool,
+	watchErrCh chan error,
+	multi *pterm.MultiPrinter,
+	changesWriterMap map[string]*pterm.SpinnerPrinter,
+	gph *apiv1.Graph,
+	rel *apiv1.Release,
+) {
+	resourceMap := make(map[string]apiv1.Resource)
+	ioWriterMap := make(map[string]io.Writer)
 	toBeWatched := apiv1.Resources{}
-	for _, res := range planResources.Resources {
+
+	// Get the resources to be watched.
+	for _, res := range rel.Spec.Resources {
 		if changes.ChangeOrder.ChangeSteps[res.ResourceKey()].Action != models.UnChanged {
+			resourceMap[res.ResourceKey()] = res
 			toBeWatched = append(toBeWatched, res)
 		}
 	}
 
-	// watch operation
-	wo := &operation.WatchOperation{}
-	if err := wo.Watch(&operation.WatchRequest{
-		Request: models.Request{
-			Project: changes.Project(),
-			Stack:   changes.Stack(),
-		},
-		Spec: &apiv1.Spec{Resources: toBeWatched},
-	}); err != nil {
-		return err
-	}
+	go func() {
+		defer func() {
+			log.Debug("entering defer func() for watch()")
+			if p := recover(); p != nil {
+				cmdutil.RecoverErr(err)
+				log.Error(*err)
+			}
+			if *err != nil {
+				if !releaseCreated {
+					return
+				}
+				release.UpdateReleasePhase(rel, apiv1.ReleasePhaseFailed, relLock)
+				_ = release.UpdateApplyRelease(releaseStorage, rel, dryRun, relLock)
+			}
+			watchErrCh <- *err
+		}()
+		// Init the runtimes according to the resource types.
+		runtimes, s := runtimeinit.Runtimes(*rel.Spec, *rel.State)
+		if v1.IsErr(s) {
+			panic(fmt.Errorf("failed to init runtimes: %s", s.String()))
+		}
 
-	fmt.Println("Watch Finish! All resources have been reconciled.")
-	return nil
+		// Prepare the tables for printing the details of the resources.
+		tables := make(map[string]*printers.Table, len(toBeWatched))
+		ticker := time.NewTicker(time.Millisecond * 100)
+		defer ticker.Stop()
+
+		// Record the watched and finished resources.
+		watchedIDs := []string{}
+		finished := make(map[string]bool)
+
+		for !(len(finished) == len(toBeWatched)) {
+			select {
+			// Get the resource ID to be watched.
+			case id := <-ac.WatchCh:
+				log.Debug("entering case id := <-ac.WatchCh")
+				log.Debug("id", id)
+				res := resourceMap[id]
+				log.Debug("res.Type", res.Type)
+				// Set the timeout duration for watch context, here we set an experiential value of 60 minutes.
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(120))
+				defer cancel()
+
+				// Get the event channel for watching the resource.
+				rsp := runtimes[res.Type].Watch(ctx, &runtime.WatchRequest{Resource: &res})
+				log.Debug("rsp", rsp)
+				if rsp == nil {
+					log.Debug("unsupported resource type: %s", res.Type)
+					continue
+				}
+				if v1.IsErr(rsp.Status) {
+					panic(fmt.Errorf("failed to watch %s as %s", id, rsp.Status.String()))
+				}
+
+				w := rsp.Watchers
+				table := printers.NewTable(w.IDs)
+				tables[id] = table
+
+				// Setup a go-routine to concurrently watch K8s and TF resources.
+				if res.Type == apiv1.Kubernetes {
+					healthPolicy, kind := getHealthPolicy(&res)
+					log.Debug("healthPolicyhealthPolicyhealthPolicyhealthPolicyhealthPolicy", healthPolicy)
+					go watchK8sResources(id, kind, w.Watchers, table, tables, gph, dryRun, healthPolicy, rel)
+				} else if res.Type == apiv1.Terraform {
+					go watchTFResources(id, w.TFWatcher, table, dryRun, rel)
+				} else {
+					log.Debug("unsupported resource type to watch: %s", string(res.Type))
+					continue
+				}
+
+				// Record the io writer related to the resource ID.
+				ioWriterMap[id] = multi.NewWriter()
+				watchedIDs = append(watchedIDs, id)
+
+			// Refresh the tables printing details of the resources to be watched.
+			default:
+				for _, id := range watchedIDs {
+					w, ok := ioWriterMap[id]
+					if !ok {
+						panic(fmt.Errorf("failed to get io writer while watching %s", id))
+					}
+					printTable(&w, id, tables)
+				}
+				for id, table := range tables {
+					if finished[id] {
+						continue
+					}
+
+					if table.AllCompleted() {
+						finished[id] = true
+						changesWriterMap[id].Success(fmt.Sprintf("Succeeded %s", pterm.Bold.Sprint(id)))
+
+						// Update resource status to reconciled.
+						resource := graph.FindGraphResourceByID(gph.Resources, id)
+						if resource != nil {
+							resource.Status = apiv1.Reconciled
+						}
+					}
+				}
+				<-ticker.C
+			}
+		}
+	}()
 }
 
 type lineSummary struct {
@@ -212,5 +362,303 @@ func (ls *lineSummary) Count(op models.ActionType) {
 		ls.updated++
 	case models.Delete:
 		ls.deleted++
+	}
+}
+
+// PrintApplyDetails function will receive the messages of the apply operation and print the details.
+// Fixme: abstract the input variables into a struct.
+func PrintApplyDetails(
+	ac *operation.ApplyOperation,
+	err *error,
+	errWriter *io.Writer,
+	wg *sync.WaitGroup,
+	changes *models.Changes,
+	changesWriterMap map[string]*pterm.SpinnerPrinter,
+	progressbar *pterm.ProgressbarPrinter,
+	ls *lineSummary,
+	dryRun bool,
+	watch bool,
+	gphResources *apiv1.GraphResources,
+	gph *apiv1.Graph,
+	rel *apiv1.Release,
+) {
+	defer func() {
+		if p := recover(); p != nil {
+			cmdutil.RecoverErr(err)
+			log.Error(*err)
+		}
+		if *err != nil {
+			if !releaseCreated {
+				return
+			}
+			release.UpdateReleasePhase(rel, apiv1.ReleasePhaseFailed, relLock)
+			*err = errors.Join([]error{*err, release.UpdateApplyRelease(releaseStorage, rel, dryRun, relLock)}...)
+		}
+		(*errWriter).(*bytes.Buffer).Reset()
+	}()
+	wg.Add(1)
+
+	for {
+		select {
+		// Get operation results from the message channel.
+		case msg, ok := <-ac.MsgCh:
+			if !ok {
+				wg.Done()
+				return
+			}
+			changeStep := changes.Get(msg.ResourceID)
+
+			// Update the progressbar and spinner printer according to the operation result.
+			switch msg.OpResult {
+			case models.Success, models.Skip:
+				var title string
+				if changeStep.Action == models.UnChanged {
+					title = fmt.Sprintf("Skipped %s", pterm.Bold.Sprint(changeStep.ID))
+					changesWriterMap[msg.ResourceID].Success(title)
+				} else {
+					if watch && !dryRun {
+						title = fmt.Sprintf("%s %s",
+							changeStep.Action.Ing(),
+							pterm.Bold.Sprint(changeStep.ID),
+						)
+						changesWriterMap[msg.ResourceID].UpdateText(title)
+					} else {
+						changesWriterMap[msg.ResourceID].Success(fmt.Sprintf("Succeeded %s", pterm.Bold.Sprint(msg.ResourceID)))
+					}
+				}
+
+				// Update resource status
+				if !dryRun && changeStep.Action != models.UnChanged {
+					gphResource := graph.FindGraphResourceByID(gphResources, msg.ResourceID)
+					if gphResource != nil {
+						// Delete resource from the graph if it's deleted during apply
+						if changeStep.Action == models.Delete {
+							graph.RemoveResource(gph, gphResource)
+						} else {
+							gphResource.Status = apiv1.ApplySucceed
+						}
+					}
+				}
+
+				progressbar.Increment()
+				ls.Count(changeStep.Action)
+			case models.Failed:
+				title := fmt.Sprintf("Failed %s", pterm.Bold.Sprint(changeStep.ID))
+				changesWriterMap[msg.ResourceID].Fail(title)
+				errStr := pretty.ErrorT.Sprintf("apply %s failed as: %s\n", msg.ResourceID, msg.OpErr.Error())
+				pterm.Fprintln(*errWriter, errStr)
+				if !dryRun {
+					// Update resource status, in case anything like update fail happened
+					gphResource := graph.FindGraphResourceByID(gphResources, msg.ResourceID)
+					if gphResource != nil {
+						gphResource.Status = apiv1.ApplyFail
+					}
+				}
+			default:
+				title := fmt.Sprintf("%s %s",
+					changeStep.Action.Ing(),
+					pterm.Bold.Sprint(changeStep.ID),
+				)
+				changesWriterMap[msg.ResourceID].UpdateText(title)
+			}
+		}
+	}
+}
+
+// getHealthPolicy get health policy and kind from resource for customized health check purpose
+func getHealthPolicy(res *apiv1.Resource) (healthPolicy interface{}, kind string) {
+	var ok bool
+	if res.Extensions != nil {
+		healthPolicy = res.Extensions[apiv1.FieldHealthPolicy]
+	}
+	if res.Attributes == nil {
+		panic(fmt.Errorf("resource has no Attributes field in the Spec: %s", res))
+	}
+	if kind, ok = res.Attributes[apiv1.FieldKind].(string); !ok {
+		panic(fmt.Errorf("failed to get kind from resource attributes: %s", res.Attributes))
+	}
+	return healthPolicy, kind
+}
+
+func watchK8sResources(
+	id, kind string,
+	chs []<-chan watch.Event,
+	table *printers.Table,
+	tables map[string]*printers.Table,
+	gph *apiv1.Graph,
+	dryRun bool,
+	healthPolicy interface{},
+	rel *apiv1.Release,
+) {
+	defer func() {
+		var err error
+		if p := recover(); p != nil {
+			cmdutil.RecoverErr(&err)
+			log.Error(err)
+		}
+		if err != nil {
+			if !releaseCreated {
+				return
+			}
+			release.UpdateReleasePhase(rel, apiv1.ReleasePhaseFailed, relLock)
+			_ = release.UpdateApplyRelease(releaseStorage, rel, dryRun, relLock)
+		}
+	}()
+
+	// Set resource status to `reconcile failed` before reconcile successfully.
+	resource := graph.FindGraphResourceByID(gph.Resources, id)
+	if resource != nil {
+		resource.Status = apiv1.ReconcileFail
+	}
+
+	// Resources selects
+	cases := createSelectCases(chs)
+	// Default select
+	cases = append(cases, reflect.SelectCase{
+		Dir:  reflect.SelectDefault,
+		Chan: reflect.Value{},
+		Send: reflect.Value{},
+	})
+
+	for {
+		chosen, recv, recvOK := reflect.Select(cases)
+		if cases[chosen].Dir == reflect.SelectDefault {
+			continue
+		}
+		if recvOK {
+			e := recv.Interface().(watch.Event)
+			o := e.Object.(*unstructured.Unstructured)
+			var detail string
+			var ready bool
+			if e.Type == watch.Deleted {
+				detail = fmt.Sprintf("%s has beed deleted", o.GetName())
+				ready = true
+			} else {
+				// Restore to actual type
+				target := printers.Convert(o)
+				// Check reconcile status with customized health policy for specific resource
+				if healthPolicy != nil && kind == o.GetObjectKind().GroupVersionKind().Kind {
+					log.Debug("healthPolicy", healthPolicy)
+					if code, ok := kcl.ConvertKCLCode(healthPolicy); ok {
+						resByte, err := yaml.Marshal(o.Object)
+						log.Debug("kcl health policy code", code)
+						if err != nil {
+							log.Error(err)
+							return
+						}
+						detail, ready = printers.PrintCustomizedHealthCheck(code, resByte)
+					} else {
+						detail, ready = printers.Generate(target)
+					}
+				} else {
+					// Check reconcile status with default setup
+					detail, ready = printers.Generate(target)
+				}
+			}
+
+			// Mark ready for breaking loop
+			if ready {
+				e.Type = printers.READY
+			}
+
+			// Save watched msg
+			table.Update(
+				engine.BuildIDForKubernetes(o),
+				printers.NewRow(e.Type, o.GetKind(), o.GetName(), detail))
+
+			// Write back
+			tables[id] = table
+		}
+
+		// Break when completed
+		if table.AllCompleted() {
+			break
+		}
+	}
+}
+
+func watchTFResources(
+	id string,
+	ch <-chan runtime.TFEvent,
+	table *printers.Table,
+	dryRun bool,
+	rel *apiv1.Release,
+) {
+	defer func() {
+		var err error
+		if p := recover(); p != nil {
+			cmdutil.RecoverErr(&err)
+			log.Error(err)
+		}
+		if err != nil {
+			if !releaseCreated {
+				return
+			}
+			release.UpdateReleasePhase(rel, apiv1.ReleasePhaseFailed, relLock)
+			_ = release.UpdateApplyRelease(releaseStorage, rel, dryRun, relLock)
+		}
+	}()
+
+	for {
+		parts := strings.Split(id, engine.Separator)
+		// A valid Terraform resource ID should consist of 4 parts, including the information of the provider type
+		// and resource name, for example: hashicorp:random:random_password:example-dev-kawesome.
+		if len(parts) != 4 {
+			panic(fmt.Errorf("invalid Terraform resource id: %s", id))
+		}
+
+		tfEvent := <-ch
+		if tfEvent == runtime.TFApplying {
+			table.Update(
+				id,
+				printers.NewRow(watch.EventType("Applying"),
+					strings.Join([]string{parts[1], parts[2]}, engine.Separator), parts[3], "Applying..."))
+		} else if tfEvent == runtime.TFSucceeded {
+			table.Update(
+				id,
+				printers.NewRow(printers.READY,
+					strings.Join([]string{parts[1], parts[2]}, engine.Separator), parts[3], "Apply succeeded"))
+		} else {
+			table.Update(
+				id,
+				printers.NewRow(watch.EventType("Failed"),
+					strings.Join([]string{parts[1], parts[2]}, engine.Separator), parts[3], "Apply failed"))
+		}
+
+		// Break when all completed.
+		if table.AllCompleted() {
+			break
+		}
+	}
+}
+
+func createSelectCases(chs []<-chan watch.Event) []reflect.SelectCase {
+	cases := make([]reflect.SelectCase, 0, len(chs))
+	for _, ch := range chs {
+		cases = append(cases, reflect.SelectCase{
+			Dir:  reflect.SelectRecv,
+			Chan: reflect.ValueOf(ch),
+		})
+	}
+	return cases
+}
+func printTable(w *io.Writer, id string, tables map[string]*printers.Table) {
+	// Reset the buffer for live flushing.
+	(*w).(*bytes.Buffer).Reset()
+
+	// Print resource Key as heading text
+	_, _ = fmt.Fprintln(*w, pretty.LightCyanBold("[%s]", id))
+
+	table, ok := tables[id]
+	if !ok {
+		// Unsupported resource, leave a hint
+		_, _ = fmt.Fprintln(*w, "Skip monitoring unsupported resources")
+	} else {
+		// Print table
+		data := table.Print()
+		_ = pterm.DefaultTable.
+			WithStyle(pterm.NewStyle(pterm.FgDefault)).
+			WithHeaderStyle(pterm.NewStyle(pterm.FgDefault)).
+			WithHasHeader().WithSeparator("  ").WithData(data).WithWriter(*w).Render()
 	}
 }

--- a/pkg/engine/api/preview.go
+++ b/pkg/engine/api/preview.go
@@ -12,7 +12,6 @@ import (
 	"kusionstack.io/kusion/pkg/engine/runtime/terraform"
 	"kusionstack.io/kusion/pkg/infra/util/semaphore"
 	"kusionstack.io/kusion/pkg/log"
-	"kusionstack.io/kusion/pkg/util/terminal"
 )
 
 type APIOptions struct {
@@ -22,7 +21,7 @@ type APIOptions struct {
 	DryRun        bool
 	MaxConcurrent int
 	Watch         bool
-	UI            *terminal.UI
+	WatchTimeout  int
 }
 
 func NewAPIOptions() APIOptions {

--- a/pkg/engine/api/preview.go
+++ b/pkg/engine/api/preview.go
@@ -12,6 +12,7 @@ import (
 	"kusionstack.io/kusion/pkg/engine/runtime/terraform"
 	"kusionstack.io/kusion/pkg/infra/util/semaphore"
 	"kusionstack.io/kusion/pkg/log"
+	"kusionstack.io/kusion/pkg/util/terminal"
 )
 
 type APIOptions struct {
@@ -20,6 +21,8 @@ type APIOptions struct {
 	IgnoreFields  []string
 	DryRun        bool
 	MaxConcurrent int
+	Watch         bool
+	UI            *terminal.UI
 }
 
 func NewAPIOptions() APIOptions {

--- a/pkg/engine/release/util.go
+++ b/pkg/engine/release/util.go
@@ -59,7 +59,7 @@ func NewApplyRelease(storage Storage, project, stack, workspace string) (*v1.Rel
 		if err != nil {
 			return nil, err
 		}
-		if lastRelease.Phase != v1.ReleasePhaseSucceeded && lastRelease.Phase != v1.ReleasePhaseFailed && lastRelease.Phase != v1.ReleasePhaseApplying {
+		if lastRelease.Phase != v1.ReleasePhaseSucceeded && lastRelease.Phase != v1.ReleasePhaseFailed {
 			return nil, fmt.Errorf("cannot create a new release of project: %s, workspace: %s. There is a release:%v in progress",
 				project, workspace, lastRelease.Revision)
 		}
@@ -107,7 +107,7 @@ func CreateDestroyRelease(storage Storage, project, stack, workspace string) (*v
 	if err != nil {
 		return nil, err
 	}
-	if lastRelease.Phase != v1.ReleasePhaseSucceeded && lastRelease.Phase != v1.ReleasePhaseFailed && lastRelease.Phase != v1.ReleasePhaseApplying {
+	if lastRelease.Phase != v1.ReleasePhaseSucceeded && lastRelease.Phase != v1.ReleasePhaseFailed {
 		return nil, fmt.Errorf("cannot create release of project %s, workspace %s cause there is release in progress", project, workspace)
 	}
 

--- a/pkg/engine/release/util.go
+++ b/pkg/engine/release/util.go
@@ -59,7 +59,7 @@ func NewApplyRelease(storage Storage, project, stack, workspace string) (*v1.Rel
 		if err != nil {
 			return nil, err
 		}
-		if lastRelease.Phase != v1.ReleasePhaseSucceeded && lastRelease.Phase != v1.ReleasePhaseFailed {
+		if lastRelease.Phase != v1.ReleasePhaseSucceeded && lastRelease.Phase != v1.ReleasePhaseFailed && lastRelease.Phase != v1.ReleasePhaseApplying {
 			return nil, fmt.Errorf("cannot create a new release of project: %s, workspace: %s. There is a release:%v in progress",
 				project, workspace, lastRelease.Revision)
 		}
@@ -107,7 +107,7 @@ func CreateDestroyRelease(storage Storage, project, stack, workspace string) (*v
 	if err != nil {
 		return nil, err
 	}
-	if lastRelease.Phase != v1.ReleasePhaseSucceeded && lastRelease.Phase != v1.ReleasePhaseFailed {
+	if lastRelease.Phase != v1.ReleasePhaseSucceeded && lastRelease.Phase != v1.ReleasePhaseFailed && lastRelease.Phase != v1.ReleasePhaseApplying {
 		return nil, fmt.Errorf("cannot create release of project %s, workspace %s cause there is release in progress", project, workspace)
 	}
 

--- a/pkg/engine/runtime/kubernetes/kubernetes_runtime.go
+++ b/pkg/engine/runtime/kubernetes/kubernetes_runtime.go
@@ -393,6 +393,7 @@ func (k *KubernetesRuntime) Watch(ctx context.Context, request *runtime.WatchReq
 		amount := 1
 		// Try to get dependent resource by owner reference
 		dependentGVK := getDependentGVK(reqObj.GroupVersionKind())
+		log.Debug("dependentGVK", dependentGVK)
 		if !dependentGVK.Empty() {
 			owner := reqObj
 			for !dependentGVK.Empty() {
@@ -719,11 +720,12 @@ func getDependentGVK(gvk schema.GroupVersionKind) schema.GroupVersionKind {
 	switch gvk.Kind {
 	// Deployment generates ReplicaSet
 	case convertor.Deployment:
-		return schema.GroupVersionKind{
-			Group:   appsv1.SchemeGroupVersion.Group,
-			Version: appsv1.SchemeGroupVersion.Version,
-			Kind:    convertor.ReplicaSet,
-		}
+		return schema.GroupVersionKind{}
+		// return schema.GroupVersionKind{
+		// 	Group:   appsv1.SchemeGroupVersion.Group,
+		// 	Version: appsv1.SchemeGroupVersion.Version,
+		// 	Kind:    convertor.ReplicaSet,
+		// }
 	// DaemonSet and StatefulSet generate ControllerRevision
 	case convertor.DaemonSet, convertor.StatefulSet:
 		return schema.GroupVersionKind{

--- a/pkg/engine/runtime/kubernetes/kubernetes_runtime.go
+++ b/pkg/engine/runtime/kubernetes/kubernetes_runtime.go
@@ -393,7 +393,7 @@ func (k *KubernetesRuntime) Watch(ctx context.Context, request *runtime.WatchReq
 		amount := 1
 		// Try to get dependent resource by owner reference
 		dependentGVK := getDependentGVK(reqObj.GroupVersionKind())
-		log.Debug("dependentGVK", dependentGVK)
+		log.Debug("watching dependent GVK: ", dependentGVK)
 		if !dependentGVK.Empty() {
 			owner := reqObj
 			for !dependentGVK.Empty() {
@@ -720,12 +720,12 @@ func getDependentGVK(gvk schema.GroupVersionKind) schema.GroupVersionKind {
 	switch gvk.Kind {
 	// Deployment generates ReplicaSet
 	case convertor.Deployment:
-		return schema.GroupVersionKind{}
-		// return schema.GroupVersionKind{
-		// 	Group:   appsv1.SchemeGroupVersion.Group,
-		// 	Version: appsv1.SchemeGroupVersion.Version,
-		// 	Kind:    convertor.ReplicaSet,
-		// }
+		// return schema.GroupVersionKind{}
+		return schema.GroupVersionKind{
+			Group:   appsv1.SchemeGroupVersion.Group,
+			Version: appsv1.SchemeGroupVersion.Version,
+			Kind:    convertor.ReplicaSet,
+		}
 	// DaemonSet and StatefulSet generate ControllerRevision
 	case convertor.DaemonSet, convertor.StatefulSet:
 		return schema.GroupVersionKind{

--- a/pkg/engine/runtime/kubernetes/kubernetes_runtime.go
+++ b/pkg/engine/runtime/kubernetes/kubernetes_runtime.go
@@ -13,7 +13,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
+
+	// discoveryv1 "k8s.io/api/discovery/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -354,32 +355,33 @@ func (k *KubernetesRuntime) Watch(ctx context.Context, request *runtime.WatchReq
 	watchers := runtime.NewWatchers()
 	// reqObj has only one watch event
 	watchers.Insert(engine.BuildIDForKubernetes(reqObj), events[0].Event)
-	if reqObj.GetKind() == convertor.Service { // Watch Endpoints or EndpointSlice
-		if gvk, err := k.mapper.KindFor(schema.GroupVersionResource{
-			Group:    discoveryv1.SchemeGroupVersion.Group,
-			Version:  discoveryv1.SchemeGroupVersion.Version,
-			Resource: convertor.EndpointSlice,
-		}); gvk.Empty() || err != nil { // Watch Endpoints
-			log.Errorf("k8s runtime has no kind for EndpointSlice, err: %v", err)
-			namedGVK := getNamedGVK(reqObj.GroupVersionKind())
-			events, err = k.WatchByRelation(ctx, reqObj, namedGVK, 1, namedBy)
-			if err != nil {
-				return &runtime.WatchResponse{Status: v1.NewErrorStatus(err)}
-			}
+	// if reqObj.GetKind() == convertor.Service { // Watch Endpoints or EndpointSlice
+	// 	if gvk, err := k.mapper.KindFor(schema.GroupVersionResource{
+	// 		Group:    discoveryv1.SchemeGroupVersion.Group,
+	// 		Version:  discoveryv1.SchemeGroupVersion.Version,
+	// 		Resource: convertor.EndpointSlice,
+	// 	}); gvk.Empty() || err != nil { // Watch Endpoints
+	// 		log.Errorf("k8s runtime has no kind for EndpointSlice, err: %v", err)
+	// 		namedGVK := getNamedGVK(reqObj.GroupVersionKind())
+	// 		events, err = k.WatchByRelation(ctx, reqObj, namedGVK, 1, namedBy)
+	// 		if err != nil {
+	// 			return &runtime.WatchResponse{Status: v1.NewErrorStatus(err)}
+	// 		}
 
-			// Endpoints has only one watch event
-			watchers.Insert(engine.BuildIDForKubernetes(events[0].Resource), events[0].Event)
-		} else { // Watch EndpointSlice
-			dependentGVK := getDependentGVK(reqObj.GroupVersionKind())
-			events, err = k.WatchByRelation(ctx, reqObj, dependentGVK, 1, ownedBy)
-			if err != nil {
-				return &runtime.WatchResponse{Status: v1.NewErrorStatus(err)}
-			}
+	// 		// Endpoints has only one watch event
+	// 		watchers.Insert(engine.BuildIDForKubernetes(events[0].Resource), events[0].Event)
+	// 	} else { // Watch EndpointSlice
+	// 		dependentGVK := getDependentGVK(reqObj.GroupVersionKind())
+	// 		events, err = k.WatchByRelation(ctx, reqObj, dependentGVK, 1, ownedBy)
+	// 		if err != nil {
+	// 			return &runtime.WatchResponse{Status: v1.NewErrorStatus(err)}
+	// 		}
 
-			// EndpointSlice has only one watch event
-			watchers.Insert(engine.BuildIDForKubernetes(events[0].Resource), events[0].Event)
-		}
-	} else if reqObj.GetKind() == convertor.Namespace { // Watch Namespace's default serviceAccount
+	// 		// EndpointSlice has only one watch event
+	// 		watchers.Insert(engine.BuildIDForKubernetes(events[0].Resource), events[0].Event)
+	// 	}
+	// } else
+	if reqObj.GetKind() == convertor.Namespace { // Watch Namespace's default serviceAccount
 		dependentGVK := getDependentGVK(reqObj.GroupVersionKind())
 		events, err = k.WatchByRelation(ctx, reqObj, dependentGVK, 1, isDefaultServiceAccount)
 		if err != nil {
@@ -720,12 +722,12 @@ func getDependentGVK(gvk schema.GroupVersionKind) schema.GroupVersionKind {
 	switch gvk.Kind {
 	// Deployment generates ReplicaSet
 	case convertor.Deployment:
-		// return schema.GroupVersionKind{}
-		return schema.GroupVersionKind{
-			Group:   appsv1.SchemeGroupVersion.Group,
-			Version: appsv1.SchemeGroupVersion.Version,
-			Kind:    convertor.ReplicaSet,
-		}
+		return schema.GroupVersionKind{}
+		// return schema.GroupVersionKind{
+		// 	Group:   appsv1.SchemeGroupVersion.Group,
+		// 	Version: appsv1.SchemeGroupVersion.Version,
+		// 	Kind:    convertor.ReplicaSet,
+		// }
 	// DaemonSet and StatefulSet generate ControllerRevision
 	case convertor.DaemonSet, convertor.StatefulSet:
 		return schema.GroupVersionKind{
@@ -749,11 +751,12 @@ func getDependentGVK(gvk schema.GroupVersionKind) schema.GroupVersionKind {
 		}
 	// Service is the owner of EndpointSlice
 	case convertor.Service:
-		return schema.GroupVersionKind{
-			Group:   discoveryv1.SchemeGroupVersion.Group,
-			Version: discoveryv1.SchemeGroupVersion.Version,
-			Kind:    convertor.EndpointSlice,
-		}
+		return schema.GroupVersionKind{}
+		// return schema.GroupVersionKind{
+		// 	Group:   discoveryv1.SchemeGroupVersion.Group,
+		// 	Version: discoveryv1.SchemeGroupVersion.Version,
+		// 	Kind:    convertor.EndpointSlice,
+		// }
 	// Namespace is the owner of ServiceAccount
 	case convertor.Namespace:
 		return schema.GroupVersionKind{

--- a/pkg/generators/appconfiguration/app_configurations_generator.go
+++ b/pkg/generators/appconfiguration/app_configurations_generator.go
@@ -513,9 +513,9 @@ func (g *appConfigurationGenerator) callModules(projectModuleConfigs map[string]
 		if hp, ok := healthPolicy.(v1.GenericConfig); ok {
 			for _, res := range resources {
 				if res.Type == v1.Kubernetes {
-					resApiVersion, resKind := getAPIVersionKindFromAttributes(res.Attributes)
-					hpApiVersion, hpKind := getAPIVersionKindFromHealthPolicy(hp)
-					if strings.EqualFold(resApiVersion, hpApiVersion) && strings.EqualFold(resKind, hpKind) {
+					resAPIVersion, resKind := getAPIVersionKindFromAttributes(res.Attributes)
+					hpAPIVersion, hpKind := getAPIVersionKindFromHealthPolicy(hp)
+					if strings.EqualFold(resAPIVersion, hpAPIVersion) && strings.EqualFold(resKind, hpKind) {
 						patchHealthPolicy(&res, hp)
 					}
 				}

--- a/pkg/server/handler/stack/utils.go
+++ b/pkg/server/handler/stack/utils.go
@@ -102,6 +102,15 @@ func requestHelper(r *http.Request) (context.Context, *httplog.Logger, *stackman
 	forceParam, _ := strconv.ParseBool(r.URL.Query().Get("force"))
 	noCacheParam, _ := strconv.ParseBool(r.URL.Query().Get("noCache"))
 	unlockParam, _ := strconv.ParseBool(r.URL.Query().Get("unlock"))
+	watchParam, _ := strconv.ParseBool(r.URL.Query().Get("watch"))
+	watchTimeoutStr := r.URL.Query().Get("watchTimeout")
+	if watchTimeoutStr == "" {
+		watchTimeoutStr = "120"
+	}
+	watchTimeoutParam, err := strconv.Atoi(watchTimeoutStr)
+	if err != nil {
+		return nil, nil, nil, stackmanager.ErrInvalidWatchTimeout
+	}
 	importResourcesParam, _ := strconv.ParseBool(r.URL.Query().Get("importResources"))
 	specIDParam := r.URL.Query().Get("specID")
 	// TODO: Should match automatically eventually???
@@ -118,13 +127,15 @@ func requestHelper(r *http.Request) (context.Context, *httplog.Logger, *stackman
 		workspaceParam = constant.DefaultWorkspace
 	}
 	executeParams := stackmanager.StackExecuteParams{
-		Detail:          detailParam,
-		Dryrun:          dryrunParam,
-		Force:           forceParam,
-		SpecID:          specIDParam,
-		ImportResources: importResourcesParam,
-		NoCache:         noCacheParam,
-		Unlock:          unlockParam,
+		Detail:              detailParam,
+		Dryrun:              dryrunParam,
+		Force:               forceParam,
+		SpecID:              specIDParam,
+		ImportResources:     importResourcesParam,
+		NoCache:             noCacheParam,
+		Unlock:              unlockParam,
+		Watch:               watchParam,
+		WatchTimeoutSeconds: watchTimeoutParam,
 	}
 	params := stackmanager.StackRequestParams{
 		StackID:       uint(id),

--- a/pkg/server/manager/stack/execute.go
+++ b/pkg/server/manager/stack/execute.go
@@ -27,7 +27,7 @@ import (
 func (m *StackManager) GenerateSpec(ctx context.Context, params *StackRequestParams) (string, *apiv1.Spec, error) {
 	logger := logutil.GetLogger(ctx)
 	runLogger := logutil.GetRunLogger(ctx)
-	logToAll(logger, runLogger, "Info", "Starting generating spec in StackManager...")
+	logutil.LogToAll(logger, runLogger, "Info", "Starting generating spec in StackManager...")
 
 	// Get the stack entity and return error if stack ID is not found
 	stackEntity, err := m.stackRepo.Get(ctx, params.StackID)
@@ -101,7 +101,7 @@ func (m *StackManager) GenerateSpec(ctx context.Context, params *StackRequestPar
 func (m *StackManager) PreviewStack(ctx context.Context, params *StackRequestParams, requestPayload request.StackImportRequest) (*models.Changes, error) {
 	logger := logutil.GetLogger(ctx)
 	runLogger := logutil.GetRunLogger(ctx)
-	logToAll(logger, runLogger, "Info", "Starting previewing stack in StackManager...")
+	logutil.LogToAll(logger, runLogger, "Info", "Starting previewing stack in StackManager...")
 
 	// Get the stack entity by id
 	stackEntity, err := m.stackRepo.Get(ctx, params.StackID)
@@ -114,7 +114,7 @@ func (m *StackManager) PreviewStack(ctx context.Context, params *StackRequestPar
 
 	defer func() {
 		if err != nil {
-			logToAll(logger, runLogger, "Info", "Error occurred during previewing stack. Setting stack sync state to preview failed")
+			logutil.LogToAll(logger, runLogger, "Info", "Error occurred during previewing stack. Setting stack sync state to preview failed")
 			stackEntity.SyncState = constant.StackStatePreviewFailed
 			m.stackRepo.Update(ctx, stackEntity)
 		} else {
@@ -164,7 +164,7 @@ func (m *StackManager) PreviewStack(ctx context.Context, params *StackRequestPar
 	if err != nil {
 		return nil, err
 	}
-	logToAll(logger, runLogger, "Info", "State storage found with path", "releasePath", releasePath)
+	logutil.LogToAll(logger, runLogger, "Info", "State storage found with path", "releasePath", releasePath)
 
 	directory, workDir, err := m.GetWorkdirAndDirectory(ctx, params, stackEntity)
 	if err != nil {
@@ -188,7 +188,7 @@ func (m *StackManager) PreviewStack(ctx context.Context, params *StackRequestPar
 	// return immediately if no resource found in stack
 	// todo: if there is no resource, should still do diff job; for now, if output is json format, there is no hint
 	if sp == nil || len(sp.Resources) == 0 {
-		logToAll(logger, runLogger, "Info", "No resource change found in this stack...")
+		logutil.LogToAll(logger, runLogger, "Info", "No resource change found in this stack...")
 		return nil, nil
 	}
 
@@ -211,7 +211,7 @@ func (m *StackManager) PreviewStack(ctx context.Context, params *StackRequestPar
 	if params.ExecuteParams.ImportResources && len(requestPayload.ImportedResources) > 0 {
 		m.ImportTerraformResourceID(ctx, sp, requestPayload.ImportedResources)
 	}
-	logToAll(logger, runLogger, "Info", "Final Spec is: ", "spec", sp)
+	logutil.LogToAll(logger, runLogger, "Info", "Final Spec is: ", "spec", sp)
 
 	changes, err := engineapi.Preview(executeOptions, releaseStorage, sp, state, project, stack)
 	return changes, err
@@ -220,7 +220,7 @@ func (m *StackManager) PreviewStack(ctx context.Context, params *StackRequestPar
 func (m *StackManager) ApplyStack(ctx context.Context, params *StackRequestParams, requestPayload request.StackImportRequest) error {
 	logger := logutil.GetLogger(ctx)
 	runLogger := logutil.GetRunLogger(ctx)
-	logToAll(logger, runLogger, "Info", "Starting applying stack in StackManager ...")
+	logutil.LogToAll(logger, runLogger, "Info", "Starting applying stack in StackManager ...")
 	_, stackBackend, project, _, ws, err := m.metaHelper(ctx, params.StackID, params.Workspace)
 	if err != nil {
 		return err
@@ -239,10 +239,10 @@ func (m *StackManager) ApplyStack(ctx context.Context, params *StackRequestParam
 	// If specID is explicitly specified by the caller, use the spec with the specID
 	if params.ExecuteParams.SpecID != "" {
 		specID = params.ExecuteParams.SpecID
-		logToAll(logger, runLogger, "Info", "SpecID explicitly set. Using the specified version", "SpecID", specID)
+		logutil.LogToAll(logger, runLogger, "Info", "SpecID explicitly set. Using the specified version", "SpecID", specID)
 	} else {
 		specID = stackEntity.LastPreviewedRevision
-		logToAll(logger, runLogger, "Info", "SpecID not explicitly set. Using last previewed version", "SpecID", stackEntity.LastPreviewedRevision)
+		logutil.LogToAll(logger, runLogger, "Info", "SpecID not explicitly set. Using last previewed version", "SpecID", stackEntity.LastPreviewedRevision)
 	}
 
 	var storage release.Storage
@@ -300,7 +300,7 @@ func (m *StackManager) ApplyStack(ctx context.Context, params *StackRequestParam
 	if err != nil {
 		return err
 	}
-	logToAll(logger, runLogger, "Info", "State storage found with path", "releasePath", releasePath)
+	logutil.LogToAll(logger, runLogger, "Info", "State storage found with path", "releasePath", releasePath)
 	if err != nil {
 		return err
 	}
@@ -340,7 +340,7 @@ func (m *StackManager) ApplyStack(ctx context.Context, params *StackRequestParam
 	}
 	executeOptions := BuildOptions(params.ExecuteParams.Dryrun, m.maxConcurrent)
 
-	logToAll(logger, runLogger, "Info", "Previewing using the default generator ...")
+	logutil.LogToAll(logger, runLogger, "Info", "Previewing using the default generator ...")
 
 	directory, workDir, err := m.GetWorkdirAndDirectory(ctx, params, stackEntity)
 	if err != nil {
@@ -364,7 +364,7 @@ func (m *StackManager) ApplyStack(ctx context.Context, params *StackRequestParam
 	// return immediately if no resource found in stack
 	// todo: if there is no resource, should still do diff job; for now, if output is json format, there is no hint
 	if sp == nil || len(sp.Resources) == 0 {
-		logToAll(logger, runLogger, "Info", "No resource change found in this stack...")
+		logutil.LogToAll(logger, runLogger, "Info", "No resource change found in this stack...")
 		return nil
 	}
 
@@ -377,12 +377,12 @@ func (m *StackManager) ApplyStack(ctx context.Context, params *StackRequestParam
 
 	// if dry run, print the hint
 	if params.ExecuteParams.Dryrun {
-		logToAll(logger, runLogger, "Info", "Dry-run mode enabled, the above resources will be applied if dryrun is set to false")
+		logutil.LogToAll(logger, runLogger, "Info", "Dry-run mode enabled, the above resources will be applied if dryrun is set to false")
 		err = ErrDryrunApply
 		return err
 	}
 
-	logToAll(logger, runLogger, "Info", "State backend found", "stateBackend", stateBackend)
+	logutil.LogToAll(logger, runLogger, "Info", "State backend found", "stateBackend", stateBackend)
 	stack.Path = tempPath(stackEntity.Path)
 
 	// Set context from workspace to spec
@@ -404,14 +404,15 @@ func (m *StackManager) ApplyStack(ctx context.Context, params *StackRequestParam
 		return err
 	}
 
-	logToAll(logger, runLogger, "Info", "Start applying diffs ...")
+	logutil.LogToAll(logger, runLogger, "Info", "Start applying diffs ...")
 	release.UpdateReleasePhase(rel, apiv1.ReleasePhaseApplying, relLock)
 	if err = release.UpdateApplyRelease(storage, rel, params.ExecuteParams.Dryrun, relLock); err != nil {
 		return err
 	}
 
 	executeOptions = BuildOptions(params.ExecuteParams.Dryrun, m.maxConcurrent)
-	executeOptions.Watch = true
+	executeOptions.Watch = params.ExecuteParams.Watch
+	executeOptions.WatchTimeout = params.ExecuteParams.WatchTimeoutSeconds
 
 	// Get graph storage directory, create if not exist
 	graphStorage, err := stackBackend.GraphStorage(project.Name, ws.Name)
@@ -465,7 +466,7 @@ func (m *StackManager) ApplyStack(ctx context.Context, params *StackRequestParam
 func (m *StackManager) DestroyStack(ctx context.Context, params *StackRequestParams, w http.ResponseWriter) (err error) {
 	logger := logutil.GetLogger(ctx)
 	runLogger := logutil.GetRunLogger(ctx)
-	logToAll(logger, runLogger, "Info", "Starting destroying stack in StackManager ...")
+	logutil.LogToAll(logger, runLogger, "Info", "Starting destroying stack in StackManager ...")
 
 	// Get the stack entity by id
 	stackEntity, err := m.stackRepo.Get(ctx, params.StackID)
@@ -525,7 +526,7 @@ func (m *StackManager) DestroyStack(ctx context.Context, params *StackRequestPar
 	if err != nil {
 		return err
 	}
-	logToAll(logger, runLogger, "Info", "State storage found with path", "releasePath", releasePath)
+	logutil.LogToAll(logger, runLogger, "Info", "State storage found with path", "releasePath", releasePath)
 	if err != nil {
 		return err
 	}
@@ -564,7 +565,7 @@ func (m *StackManager) DestroyStack(ctx context.Context, params *StackRequestPar
 
 	// if dryrun, print the hint
 	if params.ExecuteParams.Dryrun {
-		logToAll(logger, runLogger, "Info", "Dry-run mode enabled, the above resources will be destroyed if dryrun is set to false")
+		logutil.LogToAll(logger, runLogger, "Info", "Dry-run mode enabled, the above resources will be destroyed if dryrun is set to false")
 		return ErrDryrunDestroy
 	}
 
@@ -574,7 +575,7 @@ func (m *StackManager) DestroyStack(ctx context.Context, params *StackRequestPar
 		return
 	}
 	// Destroy
-	logToAll(logger, runLogger, "Info", "Start destroying resources......")
+	logutil.LogToAll(logger, runLogger, "Info", "Start destroying resources......")
 	var upRel *apiv1.Release
 
 	upRel, err = engineapi.Destroy(executeOptions, rel, changes, storage)

--- a/pkg/server/manager/stack/execute.go
+++ b/pkg/server/manager/stack/execute.go
@@ -411,6 +411,7 @@ func (m *StackManager) ApplyStack(ctx context.Context, params *StackRequestParam
 	}
 
 	executeOptions = BuildOptions(params.ExecuteParams.Dryrun, m.maxConcurrent)
+	executeOptions.Watch = true
 
 	// Get graph storage directory, create if not exist
 	graphStorage, err := stackBackend.GraphStorage(project.Name, ws.Name)

--- a/pkg/server/manager/stack/types.go
+++ b/pkg/server/manager/stack/types.go
@@ -26,6 +26,7 @@ var (
 	ErrStackInOperation                          = errors.New("the stack is being operated by another request. Please wait until it is completed")
 	ErrStackNotPreviewedYet                      = errors.New("the stack has not been previewed yet. Please generate and preview the stack first")
 	ErrInvalidRunID                              = errors.New("the run ID should be a uuid")
+	ErrInvalidWatchTimeout                       = errors.New("watchTimeout should be a number")
 )
 
 type StackManager struct {
@@ -53,13 +54,15 @@ type StackRequestParams struct {
 }
 
 type StackExecuteParams struct {
-	Detail          bool
-	Dryrun          bool
-	SpecID          string
-	Force           bool
-	ImportResources bool
-	NoCache         bool
-	Unlock          bool
+	Detail              bool
+	Dryrun              bool
+	SpecID              string
+	Force               bool
+	ImportResources     bool
+	NoCache             bool
+	Unlock              bool
+	Watch               bool
+	WatchTimeoutSeconds int
 }
 
 type RunRequestParams struct {

--- a/pkg/server/manager/stack/util.go
+++ b/pkg/server/manager/stack/util.go
@@ -27,6 +27,7 @@ import (
 	workspacemanager "kusionstack.io/kusion/pkg/server/manager/workspace"
 	logutil "kusionstack.io/kusion/pkg/server/util/logging"
 	"kusionstack.io/kusion/pkg/util/diff"
+	"kusionstack.io/kusion/pkg/util/terminal"
 )
 
 func BuildOptions(dryrun bool, maxConcurrent int) *engineapi.APIOptions {
@@ -36,6 +37,8 @@ func BuildOptions(dryrun bool, maxConcurrent int) *engineapi.APIOptions {
 		// IgnoreFields: []string{},
 		DryRun:        dryrun,
 		MaxConcurrent: maxConcurrent,
+		// Watch:         false,
+		UI: terminal.DefaultUI(),
 	}
 	return executeOptions
 }

--- a/pkg/server/manager/stack/util.go
+++ b/pkg/server/manager/stack/util.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-chi/httplog/v2"
 	"gorm.io/gorm"
 	v1 "kusionstack.io/kusion/pkg/apis/api.kusion.io/v1"
 	"kusionstack.io/kusion/pkg/backend"
@@ -27,7 +26,6 @@ import (
 	workspacemanager "kusionstack.io/kusion/pkg/server/manager/workspace"
 	logutil "kusionstack.io/kusion/pkg/server/util/logging"
 	"kusionstack.io/kusion/pkg/util/diff"
-	"kusionstack.io/kusion/pkg/util/terminal"
 )
 
 func BuildOptions(dryrun bool, maxConcurrent int) *engineapi.APIOptions {
@@ -38,7 +36,7 @@ func BuildOptions(dryrun bool, maxConcurrent int) *engineapi.APIOptions {
 		DryRun:        dryrun,
 		MaxConcurrent: maxConcurrent,
 		// Watch:         false,
-		UI: terminal.DefaultUI(),
+		WatchTimeout: 120,
 	}
 	return executeOptions
 }
@@ -437,25 +435,6 @@ func isInRelease(release *v1.Release, id string) bool {
 		}
 	}
 	return false
-}
-
-func logToAll(sysLogger *httplog.Logger, runLogger *httplog.Logger, level string, message string, args ...any) {
-	switch strings.ToLower(level) {
-	case "info":
-		sysLogger.Info(message, args...)
-		runLogger.Info(message, args...)
-	case "error":
-		sysLogger.Error(message, args...)
-		runLogger.Error(message, args...)
-	case "warn":
-		sysLogger.Warn(message, args...)
-		runLogger.Warn(message, args...)
-	case "debug":
-		sysLogger.Debug(message, args...)
-		runLogger.Debug(message, args...)
-	default:
-		sysLogger.Error("unknown log level", "level", level)
-	}
 }
 
 func unlockRelease(ctx context.Context, storage release.Storage) error {

--- a/pkg/server/util/logging/logger.go
+++ b/pkg/server/util/logging/logger.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"strings"
+
+	"github.com/go-chi/httplog/v2"
+)
+
+func LogToAll(sysLogger *httplog.Logger, runLogger *httplog.Logger, level string, message string, args ...any) {
+	switch strings.ToLower(level) {
+	case "info":
+		sysLogger.Info(message, args...)
+		runLogger.Info(message, args...)
+	case "error":
+		sysLogger.Error(message, args...)
+		runLogger.Error(message, args...)
+	case "warn":
+		sysLogger.Warn(message, args...)
+		runLogger.Warn(message, args...)
+	case "debug":
+		sysLogger.Debug(message, args...)
+		runLogger.Debug(message, args...)
+	default:
+		sysLogger.Error("unknown log level", "level", level)
+	}
+}


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Support watching Kubernetes resources during apply:
- Apply will finish when reconcile is done
- You can specify custom health policy for each individual resources in workspace configuration
- You can specify watch timeout (in seconds) in case the synchronous apply takes forever to return
- When the specified timeout is reached, this watch operation is considered completed and apply will return

Example customized health policy:
`workspace.yaml`:
```
context:
  KUBECONFIG_PATH: /Users/forest/.minikube.kubeconfig
modules:
  network:
    path: oci://ghcr.io/kusionstack/network
    version: 0.2.0
    configs:
      default:
        healthPolicy:
          apiVersion: v1
          kind: Service
          health.kcl: |
            # service simple example
            import regex
            watchAnnotationKey = "network.beta.kubernetes.io/watch"
            assert any k in res.metadata.annotations {
              regex.match(k, watchAnnotationKey)
            } if res, "no annotation found"
            if regex.match(res.metadata.annotations[watchAnnotationKey], r"comp.*"):
              assert regex.match(res.metadata.annotations[watchAnnotationKey], r"completed.*")
```
Example apply curl: 
Synchronous apply:
```
curl --location 'http://localhost:8080/api/v1/stacks/18/apply?workspace=dev&output=json&force=true&unlock=true&watch=true&watchTimeout=20' \
--header 'Content-Type: application/json'
```
Asynchronous apply:
```
curl --location 'http://localhost:8080/api/v1/stacks/18/apply/async?workspace=dev&output=json&force=true&unlock=true&watch=true&watchTimeout=20' \
--header 'Content-Type: application/json' \
--data '{
    "stackID": 18,
    "workspace": "dev",
    "type": "apply"
}'
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
