### PR TITLE
fix: the problem of dependency change status not being updated

### DIFF
--- a/pkg/apis/api.kusion.io/v1/resource.go
+++ b/pkg/apis/api.kusion.io/v1/resource.go
@@ -14,6 +14,11 @@
 
 package v1
 
+import (
+	"fmt"
+	jsoniter "github.com/json-iterator/go"
+)
+
 func (r *Resource) ResourceKey() string {
 	return r.ID
 }
@@ -49,4 +54,20 @@ func (rs Resources) Less(i, j int) bool {
 	default:
 		return false
 	}
+}
+
+func (r *Resource) DeepCopy() (*Resource, error) {
+	if r == nil {
+		return nil, fmt.Errorf("source resource is nil")
+	}
+	data, err := jsoniter.Marshal(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal resource: %v", err)
+	}
+	var res Resource
+	err = jsoniter.Unmarshal(data, &res)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal resource: %v", err)
+	}
+	return &res, nil
 }

--- a/pkg/apis/api.kusion.io/v1/resource.go
+++ b/pkg/apis/api.kusion.io/v1/resource.go
@@ -16,6 +16,7 @@ package v1
 
 import (
 	"fmt"
+
 	jsoniter "github.com/json-iterator/go"
 )
 

--- a/pkg/engine/operation/graph/resource_node.go
+++ b/pkg/engine/operation/graph/resource_node.go
@@ -347,6 +347,7 @@ func (rn *ResourceNode) applyResource(operation *models.Operation, prior, planed
 			log.Debugf("import resource:%s, resource:%v", planed.ID, json.Marshal2String(s))
 			res = response.Resource
 		} else {
+			prior.DependsOn = planed.DependsOn
 			res = prior
 		}
 	default:

--- a/pkg/engine/operation/graph/resource_node.go
+++ b/pkg/engine/operation/graph/resource_node.go
@@ -347,8 +347,12 @@ func (rn *ResourceNode) applyResource(operation *models.Operation, prior, planed
 			log.Debugf("import resource:%s, resource:%v", planed.ID, json.Marshal2String(s))
 			res = response.Resource
 		} else {
-			prior.DependsOn = planed.DependsOn
-			res = prior
+			copyPrior, e := prior.DeepCopy()
+			if e != nil {
+				return v1.NewErrorStatus(e)
+			}
+			res = copyPrior
+			res.DependsOn = planed.DependsOn
 		}
 	default:
 		return v1.NewErrorStatus(fmt.Errorf("unknown action type: %v", rn.Action))


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
bug
#### What this PR does / why we need it:
Resource dependency status maintenance and improvement needs

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1358

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
Solve the problem that the resources have not changed but the dependencies have changed, but the resource dependencies in status maintenance have not changed.

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
