### PR TITLE
feat: handle empty stack in preview

### DIFF
--- a/pkg/cmd/preview/preview.go
+++ b/pkg/cmd/preview/preview.go
@@ -240,12 +240,17 @@ func (o *PreviewOptions) Run() error {
 		return err
 	}
 
-	// return immediately if no resource found in stack
-	if spec == nil || len(spec.Resources) == 0 {
+	if spec == nil {
 		if o.Output != jsonOutput {
-			fmt.Println(pretty.GreenBold("\nNo resource found in this stack."))
+			fmt.Println(pretty.YellowBold("\nSpec is nil. Treating as empty spec."))
 		}
-		return nil
+		spec = &apiv1.Spec{}
+	}
+
+	if len(spec.Resources) == 0 {
+		if o.Output != jsonOutput {
+			fmt.Println(pretty.YellowBold("\nNo resources found in the spec."))
+		}
 	}
 
 	// compute state

--- a/pkg/server/manager/stack/execute.go
+++ b/pkg/server/manager/stack/execute.go
@@ -198,8 +198,7 @@ func (m *StackManager) PreviewStack(ctx context.Context, params *StackRequestPar
 		return nil, err
 	}
 
-	// return immediately if no resource found in stack
-	// todo: if there is no resource, should still do diff job; for now, if output is json format, there is no hint
+	// Treat nil spec as empty and continue with diff
 	if sp == nil {
 		logutil.LogToAll(logger, runLogger, "Warn", "Generated spec is nil, treating as empty spec...")
 		sp = &apiv1.Spec{}

--- a/pkg/server/manager/stack/execute.go
+++ b/pkg/server/manager/stack/execute.go
@@ -200,9 +200,12 @@ func (m *StackManager) PreviewStack(ctx context.Context, params *StackRequestPar
 
 	// return immediately if no resource found in stack
 	// todo: if there is no resource, should still do diff job; for now, if output is json format, there is no hint
-	if sp == nil || len(sp.Resources) == 0 {
-		logutil.LogToAll(logger, runLogger, "Info", "No resource change found in this stack...")
-		return nil, nil
+	if sp == nil {
+		logutil.LogToAll(logger, runLogger, "Warn", "Generated spec is nil, treating as empty spec...")
+		sp = &apiv1.Spec{}
+	}
+	if len(sp.Resources) == 0 {
+		logutil.LogToAll(logger, runLogger, "Info", "No resources found in spec. Proceeding with full diff.")
 	}
 
 	// Preview


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than three commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->
/kind feature 
#### What this PR does / why we need it:
It is actually valid to pass an empty spec for a preview, and Kusion should handle the preview result correctly.
This change should not affect how apply and destroy handle an empty spec.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1419 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation e.g., design docs, usage docs, etc.:

<!--
Please use the following format for linking documentation:
- [Design]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
